### PR TITLE
Update `SCRIPT_PATH` and centralize script execution logic

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -5,8 +5,6 @@ import traceback
 
 import bpy
 
-from .debug_utils import loge
-
 
 manifest_path = os.path.join(os.path.dirname(__file__), "blender_manifest.toml")
 with open(manifest_path, "rb") as f:
@@ -24,28 +22,13 @@ ICON_ENUM_ITEMS = \
     bpy.types.UILayout.bl_rna.functions["prop"].parameters["icon"].enum_items
 
 
-def uprefs(context=bpy.context):
-    """Retrieves Blender's user preferences."""
-    preferences = getattr(context, "preferences", None)
-    if preferences is None:
-        loge("Failed to retrieve user preferences.")
-        return None
-    return preferences
+def uprefs():
+    return getattr(bpy.context, "user_preferences", None) \
+        or getattr(bpy.context, "preferences", None)
 
 
-def prefs(context=bpy.context):
-    """Retrieves the preferences of this addon."""
-    preferences = uprefs(context)
-    if preferences is None:
-        loge("No preferences attribute found in the context.")
-        return None
-
-    addon_prefs = preferences.addons.get(__package__)
-    if addon_prefs is None:
-        loge(f"Addon preferences not found for package: {__package__}")
-        raise KeyError(f"Addon preferences not found: {__package__}")
-
-    return addon_prefs.preferences
+def prefs():
+    return uprefs().addons[__package__].preferences
 
 
 def temp_prefs():

--- a/addon.py
+++ b/addon.py
@@ -16,7 +16,7 @@ with open(manifest_path, "rb") as f:
             parts.append(int(part))
         VERSION = tuple(parts)
 ADDON_PATH      = os.path.normpath(os.path.dirname(os.path.abspath(__file__)))
-SCRIPT_PATH     = os.path.join(ADDON_PATH, "scripts/")
+SCRIPT_PATH     = os.path.join(ADDON_PATH, "resources", "scripts")
 SAFE_MODE       = "--pme-safe-mode" in sys.argv
 ICON_ENUM_ITEMS = \
     bpy.types.UILayout.bl_rna.functions["prop"].parameters["icon"].enum_items

--- a/addon.py
+++ b/addon.py
@@ -5,6 +5,8 @@ import traceback
 
 import bpy
 
+from .debug_utils import loge
+
 
 manifest_path = os.path.join(os.path.dirname(__file__), "blender_manifest.toml")
 with open(manifest_path, "rb") as f:
@@ -22,13 +24,28 @@ ICON_ENUM_ITEMS = \
     bpy.types.UILayout.bl_rna.functions["prop"].parameters["icon"].enum_items
 
 
-def uprefs():
-    return getattr(bpy.context, "user_preferences", None) \
-        or getattr(bpy.context, "preferences", None)
+def uprefs(context=bpy.context):
+    """Retrieves Blender's user preferences."""
+    preferences = getattr(context, "preferences", None)
+    if preferences is None:
+        loge("Failed to retrieve user preferences.")
+        return None
+    return preferences
 
 
-def prefs():
-    return uprefs().addons[__package__].preferences
+def prefs(context=bpy.context):
+    """Retrieves the preferences of this addon."""
+    preferences = uprefs(context)
+    if preferences is None:
+        loge("No preferences attribute found in the context.")
+        return None
+
+    addon_prefs = preferences.addons.get(__package__)
+    if addon_prefs is None:
+        loge(f"Addon preferences not found for package: {__package__}")
+        raise KeyError(f"Addon preferences not found: {__package__}")
+
+    return addon_prefs.preferences
 
 
 def temp_prefs():

--- a/preferences.py
+++ b/preferences.py
@@ -57,8 +57,8 @@ from .constants import (
 
 
 pp = pme.props
-import_filepath = os.path.join(ADDON_PATH, "examples", "examples.json")
-export_filepath = os.path.join(ADDON_PATH, "examples", "my_pie_menus.json")
+import_filepath = os.path.join(ADDON_PATH, "resources", "examples", "examples.json")
+export_filepath = os.path.join(ADDON_PATH, "resources", "examples", "my_pie_menus.json")
 
 
 def update_pmi_data(_self, context, reset_prop_data=True):
@@ -331,7 +331,7 @@ class WM_OT_pm_import(bpy.types.Operator, ImportHelper):
 
                 for info in f.infolist():
                     if info.is_dir():
-                        if info.filename == "icons/":
+                        if info.filename == "resources/icons/":
                             self.refresh_icons_flag = True
 
                         try:

--- a/preferences.py
+++ b/preferences.py
@@ -32,7 +32,7 @@ from .keymap_helper import (
 from .modal_utils import encode_modal_data
 from .utils import extract_str_flags, isclose
 from .compatibility_fixes import fix, fix_json
-from .ui_utils import get_pme_menu_class, execute_script
+from .ui_utils import get_pme_menu_class, execute_scripts_in_subdir
 from .ui import tag_redraw, draw_addons_maximized, is_userpref_maximized
 from .operator_utils import (
     find_operator, apply_properties, operator_label, to_bl_idname
@@ -3631,19 +3631,8 @@ def register():
     pr.tree.update()
     PME_UL_pm_tree.load_state()
 
-    for root, dirs, files in os.walk(
-            os.path.join(SCRIPT_PATH, "autorun"), followlinks=True):
-        dirs[:] = [d for d in dirs if d != "__pycache__"]
-        for file in files:
-            if file.endswith('.py'):
-                execute_script(os.path.join(root, file))
-
-    for root, dirs, files in os.walk(
-            os.path.join(SCRIPT_PATH, "register"), followlinks=True):
-        dirs[:] = [d for d in dirs if d != "__pycache__"]
-        for file in files:
-            if file.endswith('.py'):
-                execute_script(os.path.join(root, file))
+    execute_scripts_in_subdir("autorun")
+    execute_scripts_in_subdir("register")
 
 
 def unregister():
@@ -3656,9 +3645,4 @@ def unregister():
     if hasattr(bpy.types, "WM_MT_button_context"):
         bpy.types.WM_MT_button_context.remove(button_context_menu)
 
-    for root, dirs, files in os.walk(
-            os.path.join(SCRIPT_PATH, "unregister"), followlinks=True):
-        dirs[:] = [d for d in dirs if d != "__pycache__"]
-        for file in files:
-            if file.endswith('.py'):
-                execute_script(os.path.join(root, file))
+    execute_scripts_in_subdir("unregister")

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -10,7 +10,7 @@ import bpy
 from . import pme
 from .operators import WM_OT_pme_user_pie_menu_call
 from .layout_helper import CLayout, draw_pme_layout, lh
-from .addon import prefs, print_exc, ADDON_PATH
+from .addon import prefs, print_exc, ADDON_PATH, SCRIPT_PATH
 
 
 class WM_MT_pme:
@@ -191,6 +191,20 @@ def execute_script(path, **kwargs):
                     pme.context.exec_operator.report({'ERROR'}, s)
 
     return exec_globals.get("return_value", True)
+
+
+def execute_scripts_in_subdir(subdir: str) -> None:
+    """
+    Execute all Python scripts in the specified subdirectory, 
+    providing a central point for future script management and customization.
+    """
+    directory = os.path.join(SCRIPT_PATH, subdir)
+    for root, dirs, files in os.walk(directory, followlinks=True):
+        dirs[:] = [d for d in dirs if d != "__pycache__"]
+        files = [f for f in files if f.endswith('.py')]
+        files.sort()
+        for file in files:
+            execute_script(os.path.join(root, file))
 
 
 def draw_menu(name, frame=False, dx=0, dy=0, layout=None):

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -44,7 +44,7 @@ pme_menu_classes = {}
 
 def get_pme_menu_class(name):
     if name not in pme_menu_classes:
-        class_name = "PME_MT_menu_" + len(pme_menu_classes)
+        class_name = f"PME_MT_menu_{len(pme_menu_classes)}"
         pme_menu_classes[name] = type(
             class_name, (WM_MT_pme, bpy.types.Menu), {'bl_label': name}
         )


### PR DESCRIPTION
This pull request updates `SCRIPT_PATH` to align with the new file structure and introduces the `execute_scripts_in_subdir` function to reduce redundant script execution code.

### Key Changes:
1. Updated `SCRIPT_PATH` to point to `resources/scripts`.
2. Consolidated redundant script execution logic into `execute_scripts_in_subdir`.

### Notes:
- Hardcoded values (e.g., `"autorun"`) remain and will be addressed in future improvements.
- The current `execute_script` implementation is retained for compatibility and will be revisited later.
