### PR TITLE
Replace Context Dict Overrides with `temp_override`

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -208,7 +208,7 @@ def load_post_handler(_):
     if pr.missing_kms:
         bpy.ops.pme.wait_keymaps(
             dict(window=bpy.context.window_manager.windows[0]),
-            'INVOKE_DEFAULT')
+            'INVOKE_DEFAULT')  # TODO(B4.0): Replace dictionary override with context.temp_override
     else:
         temp_prefs().init_tags()
         pr.tree.update()
@@ -258,7 +258,7 @@ def on_context():
         DBG_INIT and logi("%d Missing Keymaps" % len(pr.missing_kms))
         bpy.ops.pme.wait_keymaps(
             dict(window=bpy.context.window_manager.windows[0]),
-            'INVOKE_DEFAULT')
+            'INVOKE_DEFAULT')  # TODO(B4.0): Replace dictionary override with context.temp_override
 
     else:
         compatibility_fixes.fix()

--- a/__init__.py
+++ b/__init__.py
@@ -191,8 +191,8 @@ def load_pre_handler(_):
 
 
 @persistent
-def load_post_handler(_):
-    DBG_INIT and logh("Load Post (%s)" % bpy.data.filepath)
+def load_post_handler(filepath):
+    DBG_INIT and logh("Load Post (%s)" % filepath)
 
     global tmp_data
     if tmp_data is None:
@@ -206,9 +206,9 @@ def load_post_handler(_):
     tmp_data = None
 
     if pr.missing_kms:
-        bpy.ops.pme.wait_keymaps(
-            dict(window=bpy.context.window_manager.windows[0]),
-            'INVOKE_DEFAULT')  # TODO(B4.0): Replace dictionary override with context.temp_override
+        logw(f"Missing Keymaps: {pr.missing_kms}")
+        with bpy.context.temp_override(window=bpy.context.window_manager.windows[0]):
+            bpy.ops.pme.wait_keymaps('INVOKE_DEFAULT')
     else:
         temp_prefs().init_tags()
         pr.tree.update()
@@ -255,10 +255,9 @@ def on_context():
             m.register()
 
     if pr.missing_kms:
-        DBG_INIT and logi("%d Missing Keymaps" % len(pr.missing_kms))
-        bpy.ops.pme.wait_keymaps(
-            dict(window=bpy.context.window_manager.windows[0]),
-            'INVOKE_DEFAULT')  # TODO(B4.0): Replace dictionary override with context.temp_override
+        logw(f"Missing Keymaps: {pr.missing_kms}")
+        with bpy.context.temp_override(window=bpy.context.window_manager.windows[0]):
+            bpy.ops.pme.wait_keymaps('INVOKE_DEFAULT')
 
     else:
         compatibility_fixes.fix()

--- a/bl_utils.py
+++ b/bl_utils.py
@@ -760,13 +760,13 @@ def get_space_data(area_type):
     return ret
 
 
-def get_context_data(area_type):  # TODO(B4.0): Replace dictionary override with context.temp_override
-    ret = dict()
-    ret["space_data"] = get_space_data(area_type)
-    return ret
+# def get_context_data(area_type):  # B4.0: Replace dictionary override with context.temp_override
+#     ret = dict()
+#     ret["space_data"] = get_space_data(area_type)
+#     return ret
 
 
-# TODO(B4.0): Replace dictionary override with context.temp_override
+# MIGRATION_TODO: Replace dictionary override with context.temp_override
 def ctx_dict(
         window=None, screen=None, area=None, region=None, scene=None,
         workspace=None):
@@ -787,7 +787,7 @@ def ctx_dict(
         "workspace": bl_context.workspace,
     }
 
-    # FIXME: Investigate the need for bl_context here and make sure to remove it.
+    # MIGRATION_TODO:  Investigate the need for bl_context here and make sure to remove it.
     for k, v in default_kwargs.items():
         if k not in d:
             d[k] = v
@@ -831,7 +831,8 @@ def popup_area(area, width=320, height=400, x=None, y=None):
     upr.view.ui_scale = 1
     upr.view.ui_line_width = 'THIN'
 
-    bpy.ops.screen.area_dupli(ctx_dict(area=area), 'INVOKE_DEFAULT')  # TODO(B4.0): Replace dictionary override with context.temp_override
+    with C.temp_override(**ctx_dict(area=area)):  # MIGRATION_TODO: Delete ctx_dict
+        bpy.ops.screen.area_dupli('INVOKE_DEFAULT')
 
     upr.view.ui_scale = ui_scale
     upr.view.ui_line_width = ui_line_width
@@ -861,4 +862,4 @@ def register():
     pme.context.add_global("message_box", message_box)
     pme.context.add_global("input_box", input_box)
     pme.context.add_global("close_popups", close_popups)
-    pme.context.add_global("ctx", get_context_data)  # TODO(B4.0): Replace dictionary override with context.temp_override
+    # pme.context.add_global("ctx", get_context_data)

--- a/bl_utils.py
+++ b/bl_utils.py
@@ -764,7 +764,7 @@ def get_context_data(area_type):
     ret["space_data"] = get_space_data(area_type)
     return ret
 
-
+# TODO(B4.0): Replace dictionary override with context.temp_override
 def ctx_dict(
         window=None, screen=None, area=None, region=None, scene=None,
         workspace=None):
@@ -829,7 +829,7 @@ def popup_area(area, width=320, height=400, x=None, y=None):
     upr.view.ui_scale = 1
     upr.view.ui_line_width = 'THIN'
 
-    bpy.ops.screen.area_dupli(ctx_dict(area=area), 'INVOKE_DEFAULT')
+    bpy.ops.screen.area_dupli(ctx_dict(area=area), 'INVOKE_DEFAULT')  # TODO(B4.0): Replace dictionary override with context.temp_override
 
     upr.view.ui_scale = ui_scale
     upr.view.ui_line_width = ui_line_width

--- a/bl_utils.py
+++ b/bl_utils.py
@@ -778,19 +778,19 @@ def ctx_dict(
     d = get_override_args(area=area, region=region, screen=screen,
                 window=window, scene=scene, workspace=workspace)
 
-    default_kwargs = {
-        "window": bl_context.window,
-        "screen": bl_context.screen,
-        "area": bl_context.area,
-        "region": bl_context.region,
-        "scene": bl_context.scene,
-        "workspace": bl_context.workspace,
-    }
+    # default_kwargs = {
+    #     "window": bl_context.window,
+    #     "screen": bl_context.screen,
+    #     "area": bl_context.area,
+    #     "region": bl_context.region,
+    #     "scene": bl_context.scene,
+    #     "workspace": bl_context.workspace,
+    # }
 
-    # MIGRATION_TODO:  Investigate the need for bl_context here and make sure to remove it.
-    for k, v in default_kwargs.items():
-        if k not in d:
-            d[k] = v
+    # # MIGRATION_TODO:  Investigate the need for bl_context here and make sure to remove it.
+    # for k, v in default_kwargs.items():
+    #     if k not in d:
+    #         d[k] = v
 
     return d
 

--- a/bl_utils.py
+++ b/bl_utils.py
@@ -807,6 +807,7 @@ def area_header_text_set(text=None, area=None):
         area.header_text_set()
 
 
+# FIXME: Width and Height are not actually applied.
 def popup_area(area, width=320, height=400, x=None, y=None):
     r = c_utils.area_rect(area)
 

--- a/bl_utils.py
+++ b/bl_utils.py
@@ -759,7 +759,7 @@ def get_space_data(area_type):
     return ret
 
 
-def get_context_data(area_type):
+def get_context_data(area_type):  # TODO(B4.0): Replace dictionary override with context.temp_override
     ret = dict()
     ret["space_data"] = get_space_data(area_type)
     return ret
@@ -859,4 +859,4 @@ def register():
     pme.context.add_global("message_box", message_box)
     pme.context.add_global("input_box", input_box)
     pme.context.add_global("close_popups", close_popups)
-    pme.context.add_global("ctx", get_context_data)
+    pme.context.add_global("ctx", get_context_data)  # TODO(B4.0): Replace dictionary override with context.temp_override

--- a/ed_base.py
+++ b/ed_base.py
@@ -731,6 +731,7 @@ class WM_OT_pmi_edit_auto(bpy.types.Operator):
         return {'FINISHED'}
 
     def invoke(self, context, event):
+        # TODO(B4.0): Replace dictionary override with context.temp_override
         ctx = find_context('INFO')
         area_type = not ctx and context.area.type
         args = []
@@ -1226,6 +1227,7 @@ class PME_OT_pmi_cmd_generate(bpy.types.Operator):
             if pos_args and args:
                 pos_args.append("")
 
+            # TODO(B4.0): Replace dictionary override with context.temp_override
             cmd = "bpy.ops.%s(%s%s)" % (
                 op_idname, ", ".join(pos_args), ", ".join(args))
 

--- a/examples/window_area_pie.json
+++ b/examples/window_area_pie.json
@@ -24,14 +24,14 @@
           "Header", 
           "COMMAND", 
           "TRIA_DOWN", 
-          "r = C.area.regions[0]; sd = C.space_data; on_top = r.y > C.area.y; bpy.ops.screen.region_flip(dict(region=r)) if on_top else None; sd.show_region_header = on_top or not sd.show_region_header; # TODO(B4.0): Replace dictionary override with context.temp_override", 
+          "r = C.area.regions[0]; sd = C.space_data; on_top = r.y > C.area.y; O.pme.exec_override(cmd='O.screen.region_flip()', kwargs='d=dict(region=C.area.regions[0])') if on_top else None; sd.show_region_header = on_top or not sd.show_region_header",
           0
         ], 
         [
           "Header", 
           "COMMAND", 
           "TRIA_UP", 
-          "r = C.area.regions[0]; sd = C.space_data; on_top = r.y > C.area.y; bpy.ops.screen.region_flip(dict(region=r)) if not on_top else None; sd.show_region_header = not on_top or not sd.show_region_header", 
+          "r = C.area.regions[0]; sd = C.space_data; on_top = r.y > C.area.y; O.pme.exec_override(cmd='O.screen.region_flip()', kwargs='d=dict(region=C.area.regions[0])') if not on_top else None; sd.show_region_header = not on_top or not sd.show_region_header",
           0
         ], 
         [

--- a/examples/window_area_pie.json
+++ b/examples/window_area_pie.json
@@ -24,7 +24,7 @@
           "Header", 
           "COMMAND", 
           "TRIA_DOWN", 
-          "r = C.area.regions[0]; sd = C.space_data; on_top = r.y > C.area.y; bpy.ops.screen.region_flip(dict(region=r)) if on_top else None; sd.show_region_header = on_top or not sd.show_region_header", 
+          "r = C.area.regions[0]; sd = C.space_data; on_top = r.y > C.area.y; bpy.ops.screen.region_flip(dict(region=r)) if on_top else None; sd.show_region_header = on_top or not sd.show_region_header; # TODO(B4.0): Replace dictionary override with context.temp_override", 
           0
         ], 
         [

--- a/extra_operators.py
+++ b/extra_operators.py
@@ -797,9 +797,13 @@ class PME_OT_popup_area(bpy.types.Operator):
                     bpy.ops.screen.region_flip()
 
         if 'HIDE' in self.header:
-            visible and bpy.ops.screen.header(d)
+            if visible:
+                with context.temp_override(**d):
+                    bpy.ops.screen.header()
         else:
-            not visible and bpy.ops.screen.header(d)
+            if not visible:
+                with context.temp_override(**d):
+                    bpy.ops.screen.header()
 
     def execute(self, context):
         return {'FINISHED'}
@@ -849,7 +853,7 @@ class PME_OT_popup_area(bpy.types.Operator):
         else:
             header_on_top = rh.y > area.y
 
-        self.update_header(header_on_top, header_visible, header_dict)
+        self.update_header(context, header_on_top, header_visible, header_dict)
 
         window = context.window
         windows = [w for w in context.window_manager.windows]
@@ -909,7 +913,7 @@ class PME_OT_popup_area(bpy.types.Operator):
                 new_window.screen.user_clear()
 
         if new_screen_flag:
-            self.update_header(header_on_top, header_visible, header_dict)
+            self.update_header(context, header_on_top, header_visible, header_dict)
 
         if area_type:
             if is_28():

--- a/extra_operators.py
+++ b/extra_operators.py
@@ -383,6 +383,8 @@ class PME_OT_window_auto_close(bpy.types.Operator):
     bl_options = {'INTERNAL'}
 
     def execute(self, context):
+        # TODO(B4.0): Replace dictionary override with context.temp_override
+
         # if context.window.screen.name.startswith(PME_SCREEN) or \
         #         context.window.screen.name.startswith(PME_TEMP_SCREEN):
         #     bpy.ops.wm.window_close(dict(window=context.window))
@@ -471,7 +473,7 @@ class PME_OT_area_move(bpy.types.Operator):
             self.report({'WARNING'}, "Main area not found")
             return {'CANCELLED'}
 
-        bpy.ops.view2d.scroll_up(SU.override_context(a))
+        bpy.ops.view2d.scroll_up(SU.override_context(a))  # TODO(B4.0): Replace dictionary override with context.temp_override
         return {'FINISHED'}
 
         mx, my = event.mouse_x, event.mouse_y
@@ -620,7 +622,7 @@ class PME_OT_sidearea_toggle(bpy.types.Operator):
     def close_area(self, main, area):
         CTU.swap_spaces(area, main, self.area)
         try:
-            bpy.ops.screen.area_close(dict(area=area))
+            bpy.ops.screen.area_close(dict(area=area))  # TODO(B4.0): Replace dictionary override with context.temp_override
             return
         except:
             pass
@@ -731,7 +733,7 @@ class PME_OT_sidearea_toggle(bpy.types.Operator):
                 SU.override_context(a),
                 direction='VERTICAL',
                 factor=factor,
-                **mouse)
+                **mouse)  # TODO(B4.0): Replace dictionary override with context.temp_override
 
             new_area = context.screen.areas[-1]
             new_area.ui_type = self.area
@@ -781,7 +783,7 @@ class PME_OT_popup_area(bpy.types.Operator):
 
         if 'TOP' in self.header:
             # not on_top and bpy.ops.screen.header_flip(d)
-            not on_top and bpy.ops.screen.region_flip(d)
+            not on_top and bpy.ops.screen.region_flip(d)  # TODO(B4.0): Replace dictionary override with context.temp_override
         else:
             # on_top and bpy.ops.screen.header_flip(d)
             on_top and bpy.ops.screen.region_flip(d)
@@ -882,11 +884,11 @@ class PME_OT_popup_area(bpy.types.Operator):
                 getattr(bpy.ops.pme, "timeout")(
                     ctx_dict(window=new_window),
                     'INVOKE_DEFAULT',
-                    cmd=self.cmd)
+                    cmd=self.cmd)  # TODO(B4.0): Replace dictionary override with context.temp_override
 
             new_screen_name = new_window.screen.name
             # if screen_name in bpy.data.screens:
-            if False:
+            if False:  # TODO(B4.0): Replace dictionary override with context.temp_override
                 bpy.ops.screen.delete(
                     dict(
                         window=new_window,

--- a/extra_operators.py
+++ b/extra_operators.py
@@ -404,11 +404,12 @@ class PME_OT_window_auto_close(bpy.types.Operator):
                         bpy.ops.screen.new()
 
                     bpy.ops.pme.timeout(
-                        cmd="p = %d; "
-                        "w = [w for w in C.window_manager.windows "
-                        "if w.as_pointer() == p][0]; "
-                        "bpy.ops.wm.window_close(dict(window=w)); "
-                        % w.as_pointer())  # TODO(B4.0): Replace dictionary override with context.temp_override
+                        cmd="bpy.ops.pme.exec_override("
+                            "cmd='bpy.ops.wm.window_close()', "
+                            "kwargs='p={}; "
+                            "w=[w for w in C.window_manager.windows "
+                            "if w.as_pointer() == p][0]; "
+                            "d=dict(window=w)')".format(w.as_pointer()))
 
                 # elif w.screen.name.startswith(PME_SCREEN):
                 #     used_pme_screens.add(w.screen.name)

--- a/macro_utils.py
+++ b/macro_utils.py
@@ -122,7 +122,7 @@ def add_macro(pm):
                 sub_op_idname, _, pos_args = operator_utils.find_operator(
                     pmi.text)
 
-                _, sub_op_exec_ctx, _ = operator_utils.parse_pos_args(pos_args)
+                sub_op_exec_ctx, _ = operator_utils.parse_pos_args(pos_args)
 
                 if sub_op_idname and sub_op_exec_ctx.startswith('INVOKE'):
                     sub_tp = eval("bpy.ops." + sub_op_idname).idname()
@@ -201,7 +201,7 @@ def _fill_props(props, pm, idx=1):
             sub_op_idname, args, pos_args = operator_utils.find_operator(
                 pmi.text)
 
-            _, sub_op_exec_ctx, _ = operator_utils.parse_pos_args(pos_args)
+            sub_op_exec_ctx, _ = operator_utils.parse_pos_args(pos_args)
 
             if sub_op_idname and sub_op_exec_ctx.startswith('INVOKE'):
                 args = ",".join(args)

--- a/operators.py
+++ b/operators.py
@@ -220,7 +220,7 @@ class PME_OT_exec(bpy.types.Operator):
         return self.execute(context)
 
 
-DBG_OVERRIDE = True
+DBG_OVERRIDE = False  # TODO: Move to debug_utils
 class PME_OT_exec_override(bpy.types.Operator):
     bl_idname = "pme.exec_override"
     bl_label = ""
@@ -237,26 +237,23 @@ class PME_OT_exec_override(bpy.types.Operator):
         name="Region Type",
         default='WINDOW', maxlen=MAX_STR_LEN, options={'SKIP_SAVE', 'HIDDEN'})
     kwargs: bpy.props.StringProperty(
-        name="Extra Keywords", description=r"d = {key: value, key: value, ...}",
-        default=r"d = {}", maxlen=MAX_STR_LEN, options={'SKIP_SAVE', 'HIDDEN'})
+        name="Extra Keywords",
+        description=(
+            "Python code that sets 'd' variable to override dict.\n"
+            "Example: w=C.window; d = {'area': w.screen.areas[0]}"
+        ),
+        default="d = {}", maxlen=MAX_STR_LEN, options={'SKIP_SAVE', 'HIDDEN'})
 
     def execute(self, context):
         DBG_OVERRIDE and logh(f"Executing: {self.cmd}")
-        extra_kwargs = self.parse_kwargs()
+        temp_override_args = self.parse_kwargs()
 
-        if DBG_OVERRIDE:
-            pairs = [f"  {k}: {v}" for k, v in extra_kwargs.items()]
-            logi("Extra kwargs:\n" + "\n".join(pairs))
-            print()
+        temp_override_args.setdefault("area",
+            self.area_type if self.area_type == 'CURRENT' else None)
+        temp_override_args.setdefault("region", self.region_type)
 
-        cov = SU.create_context_override(
-            area=self.area_type if self.area_type != 'CURRENT' else None,
-            region=self.region_type,
-            **extra_kwargs)
-
-        DBG_OVERRIDE and logi(f"Context override args:\n{cov}")
-
-        override_args = cov.validate(context, extra_priority=True)
+        override_args = SU.ContextOverride(**temp_override_args)\
+                            .validate(context, delete_none=True)
 
         if DBG_OVERRIDE:
             pairs = [f"  {k}: {v}" for k, v in override_args.items()]
@@ -276,8 +273,21 @@ class PME_OT_exec_override(bpy.types.Operator):
         return self.execute(context)
 
     def parse_kwargs(self):
+        """Execute kwargs code and get 'd' dict"""
+        if not self.kwargs.strip():
+            return {}
+
+        try:
+            code = compile(self.kwargs, "<override>", "exec")
+        except SyntaxError as e:
+            offset = e.offset if e.offset is not None else 0
+            pointer = " " * offset + "^"
+            self.report({'ERROR'},
+                f"Syntax error in override:\n{e.text}\n{pointer}\n{str(e)}")
+            return {}
+
         eval_globals = pme.context.gen_globals()
-        pme.context.exe(self.kwargs, eval_globals)
+        pme.context.exe(code, eval_globals)
         return eval_globals.get("d", {})
 
 

--- a/operators.py
+++ b/operators.py
@@ -249,8 +249,12 @@ class PME_OT_exec_override(bpy.types.Operator):
         temp_override_args = self.parse_kwargs()
 
         temp_override_args.setdefault("area",
-            self.area_type if self.area_type == 'CURRENT' else None)
+            self.area_type if self.area_type != 'CURRENT' else None)
         temp_override_args.setdefault("region", self.region_type)
+
+        if DBG_OVERRIDE:
+            pairs = [f"  {k}: {v}" for k, v in temp_override_args.items()]
+            logi("Context override args(defaults):\n" + "\n".join(pairs))
 
         override_args = SU.ContextOverride(**temp_override_args)\
                             .validate(context, delete_none=True)

--- a/operators.py
+++ b/operators.py
@@ -662,7 +662,7 @@ class PME_OT_timeout(bpy.types.Operator):
 
             if self.timer.time_duration >= self.delay:
                 self.cancelled = True
-                if False:
+                if False:  # TODO(B4.0): Replace dictionary override with context.temp_override
                     pass
                 # if self.area != 'CURRENT':
                 #     bpy.ops.pme.timeout(

--- a/operators.py
+++ b/operators.py
@@ -662,16 +662,13 @@ class PME_OT_timeout(bpy.types.Operator):
 
             if self.timer.time_duration >= self.delay:
                 self.cancelled = True
-                if False:  # TODO(B4.0): Replace dictionary override with context.temp_override
-                    pass
-                # if self.area != 'CURRENT':
-                #     bpy.ops.pme.timeout(
-                #         SU.override_context(self.area),
-                #         'INVOKE_DEFAULT', cmd=self.cmd, delay=self.delay)
-                else:
-                    pme.context.exec_operator = self
-                    pme.context.exe(self.cmd)
-                    pme.context.exec_operator = None
+                # if self.area != 'CURRENT':  # Refactor_TODO: Check why they no longer use Area.
+                #     with context.temp_override(area=self.area):
+                #         bpy.ops.pme.timeout('INVOKE_DEFAULT', cmd=self.cmd, delay=self.delay)
+                # else:
+                pme.context.exec_operator = self
+                pme.context.exe(self.cmd)
+                pme.context.exec_operator = None
         return {'PASS_THROUGH'}
 
     def execute(self, context):

--- a/screen_utils.py
+++ b/screen_utils.py
@@ -146,13 +146,12 @@ def find_region(
             # return bpy.context.region  # fallback
             return None
 
-        # Resolve area first
+        if isinstance(region_or_type, bpy.types.Region):
+            return region_or_type
+
         area = find_area(area_or_type, screen_or_name)
         if not area:
             return None
-
-        if isinstance(region_or_type, bpy.types.Region):
-            return region_or_type
 
         for r in area.regions:
             if r.type == region_or_type:

--- a/screen_utils.py
+++ b/screen_utils.py
@@ -10,7 +10,7 @@ def redraw_screen(area=None):
     # if not area:
     #     return
 
-    # bpy.ops.screen.screen_full_area(override_context(area))
+    # bpy.ops.screen.screen_full_area(override_context(area))  # TODO(B4.0): Replace dictionary override with context.temp_override
     # bpy.ops.screen.screen_full_area(override_context(area))
 
     view = uprefs().view
@@ -51,7 +51,7 @@ def move_header(area=None, top=None, visible=None, auto=None):
     else:
         is_top = rh.y > area.y
 
-    d = ctx_dict(area=area, region=rh)
+    d = ctx_dict(area=area, region=rh)  # TODO(B4.0): Replace dictionary override with context.temp_override
     if auto:
         if top:
             if is_top:
@@ -123,9 +123,9 @@ def focus_area(area, center=False, cmd=None):
         bpy.context.window.cursor_warp(x, y)
 
     if cmd:
-        bpy.ops.pme.timeout(override_context(area), cmd=cmd)
+        bpy.ops.pme.timeout(override_context(area), cmd=cmd)  # TODO(B4.0): Replace dictionary override with context.temp_override
 
-
+# TODO(B4.0): Replace dictionary override with context.temp_override
 def override_context(
         area, screen=None, window=None, region='WINDOW', **kwargs):
     window = window or bpy.context.window

--- a/screen_utils.py
+++ b/screen_utils.py
@@ -1,11 +1,13 @@
 import bpy
 
-from typing import Union
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Union
 
 from . import c_utils as CTU
 from . import pme
 from .addon import uprefs
 # from .bl_utils import ctx_dict
+from .debug_utils import logi
 
 
 def redraw_screen(area=None):
@@ -80,82 +82,237 @@ def move_header(area=None, top=None, visible=None, auto=None):
     return True
 
 
+# def parse_extra_keywords(kwargs_str: str) -> dict:
+#     """
+#     Parse a comma-separated string like:
+#       "window=Window, screen=Screen.001, workspace=MyWorkspace"
+#     into a dict:
+#       { "window": "Window", "screen": "Screen.001", "workspace": "MyWorkspace" }
+#     """
+#     if not kwargs_str.strip():
+#         return {}
+#     kwargs = {}
+#     for kv in kwargs_str.split(","):
+#         kv = kv.strip()
+#         if "=" not in kv:
+#             continue
+#         k, v = kv.split("=", 1)
+#         kwargs[k.strip()] = v.strip()
+#     return kwargs
+
+
 def find_area(
-    area_or_type: Union[str, bpy.types.Area],
-    screen_or_name: Union[str, bpy.types.Screen, None] = None,
-) -> Union[bpy.types.Area, None]:
-    """Find and return an Area object."""
-    if area_or_type is None:
-        area_or_type = bpy.context.area
+    area_or_type: Union[str, bpy.types.Area, None],
+    screen_or_name: Union[str, bpy.types.Screen, None] = None
+) -> Optional[bpy.types.Area]:
+    """Find and return an Area object, or None if not found."""
+    try:
+        if area_or_type is None:
+            # return bpy.context.area  # fallback
+            return None
 
-    if isinstance(area_or_type, bpy.types.Area):
-        return area_or_type
+        if isinstance(area_or_type, bpy.types.Area):
+            return area_or_type
 
-    screen = None
-    if isinstance(screen_or_name, bpy.types.Screen):
-        screen = screen_or_name
-    elif isinstance(screen_or_name, str):
-        screen = bpy.data.screens.get(screen_or_name, None)
-    else:
-        screen = bpy.context.screen
+        # Find screen
+        screen = None
+        if isinstance(screen_or_name, bpy.types.Screen):
+            screen = screen_or_name
+        elif isinstance(screen_or_name, str):
+            screen = bpy.data.screens.get(screen_or_name)
+        else:
+            screen = bpy.context.screen
 
-    if screen:
-        for a in screen.areas:
-            if a.type == area_or_type:
-                return a
+        if screen:
+            for a in screen.areas:
+                if a.type == area_or_type:
+                    return a
+
+    except ReferenceError:
+        # print_exc("find_area: invalid reference")
+        pass
 
     return None
 
 
 def find_region(
-    region_or_type: Union[str, bpy.types.Region],
-    area_or_type: Union[str, bpy.types.Area] = None,
-    screen_or_name: Union[str, bpy.types.Screen, None] = None,
-) -> Union[bpy.types.Region, None]:
-    """Find and return a Region object within the specified Area."""
-    if region_or_type is None:
-        region_or_type = bpy.context.region.type
+    region_or_type: Union[str, bpy.types.Region, None],
+    area_or_type: Union[str, bpy.types.Area, None] = None,
+    screen_or_name: Union[str, bpy.types.Screen, None] = None
+) -> Optional[bpy.types.Region]:
+    """Find and return a Region object within the specified Area, or None if not found."""
+    try:
+        if region_or_type is None:
+            # return bpy.context.region  # fallback
+            return None
 
-    area = find_area(area_or_type, screen_or_name)
-    if not area:
-        return None
+        # Resolve area first
+        area = find_area(area_or_type, screen_or_name)
+        if not area:
+            return None
 
-    if isinstance(region_or_type, bpy.types.Region):
-        return region_or_type
+        if isinstance(region_or_type, bpy.types.Region):
+            return region_or_type
 
-    for r in area.regions:
-        if r.type == region_or_type:
-            return r
+        for r in area.regions:
+            if r.type == region_or_type:
+                return r
+
+    except ReferenceError:
+        # print_exc("find_region: invalid reference")
+        pass
 
     return None
+
+
+def resolve_window(
+    value: Optional[Union[str, bpy.types.Window]],
+    context: bpy.types.Context,
+) -> Optional[bpy.types.Window]:
+    """Resolve string or Window object into a Window object, fallback to context.window if none."""
+    if isinstance(value, bpy.types.Window):
+        logi(f"resolve_window: {value}")
+        return value
+    # if isinstance(value, str):
+    #     if w := context.window_manager.windows.get(value, None):
+    #         return w
+    #     return None
+    logi(f"window fallback: {context.window}")
+    # return context.window  # fallback
+    return None
+
+
+def resolve_screen(
+    value: Optional[Union[str, bpy.types.Screen]],
+    context: bpy.types.Context
+) -> Optional[bpy.types.Screen]:
+    """Resolve string or Screen object into a Screen object, fallback to context.screen if none."""
+    if isinstance(value, bpy.types.Screen):
+        logi(f"resolve_screen: {value}")
+        return value
+    # if isinstance(value, str):
+    #     return bpy.data.screens.get(value)
+    logi(f"screen fallback: {context.screen}")
+    # return context.screen  # fallback
+    return None
+
+
+@dataclass
+class ContextOverride:
+    """
+    Container for context override parameters.
+    Allows specifying string or object references for Window/Screen/Area/Region,
+    plus any additional overrides in 'extra'.
+    """
+    window: Optional[Union[str, bpy.types.Window]] = None
+    screen: Optional[Union[str, bpy.types.Screen]] = None
+    area: Optional[Union[str, bpy.types.Area]] = None
+    region: Optional[Union[str, bpy.types.Region]] = None
+    blend_data: Optional[bpy.types.BlendData] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def validate(
+        self,
+        context: bpy.types.Context,
+        *,
+        extra_priority: bool = False,
+        delete_none: bool = True
+    ) -> Dict[str, Any]:
+        """
+        Validate and resolve all fields into actual Blender objects.
+        If 'extra_priority' is True, 'extra' keys override base fields.
+        Otherwise, base fields override 'extra'.
+
+        :param context: Must be an instance of bpy.types.Context, else TypeError
+        :param extra_priority: If True, the base fields will override keys in 'extra'
+                            (so 'extra' is applied first, then base).
+        :param delete_none: If True, remove None entries from final dict.
+        :param strict: If True, raise ValueError or TypeError if invalid references found
+                       (e.g. invalid window). If False, just fallback or ignore.
+        :return: A dict suitable for `with context.temp_override(**...)`.
+        """
+        # Resolve all fields
+        w = resolve_window(self.window, context)
+        sc = resolve_screen(self.screen, context)
+        a = find_area(self.area, sc)
+        r = find_region(self.region, self.area, sc)
+        bd = self.blend_data  # or context.blend_data
+
+        base_dict = {
+            "window": w,
+            "screen": sc,
+            "area": a,
+            "region": r,
+            "blend_data": bd,
+        }
+
+        # TODO: Extra does not check for windows, areas, etc.
+        if extra_priority:
+            primary_dict = self.extra
+            secondary_dict = base_dict
+        else:
+            primary_dict = base_dict
+            secondary_dict = self.extra
+
+        context_params = {**secondary_dict, **primary_dict}
+
+        if delete_none:
+            context_params = {k: v for k, v in context_params.items() if v is not None}
+
+        return context_params
+
+    def __str__(self):
+        return (
+            f"ContextOverride(\n"
+            f"window={self.window},\n"
+            f"screen={self.screen},\n"
+            f"area={self.area},\n"
+            f"region={self.region},\n"
+            f"blend_data={self.blend_data},\n"
+            f"extra={self.extra})\n"
+        )
+
+
+def create_context_override(
+    area: Union[str, bpy.types.Area, None] = None,
+    region: Union[str, bpy.types.Region, None] = None,  # "WINDOW",
+    # screen: Union[str, bpy.types.Screen, None] = None,  # comment out for Test
+    # window: Union[str, bpy.types.Window, None] = None,  # comment out for Test
+    # override_kwargs_str: str = "",
+    **kwargs,
+) -> ContextOverride:
+    # extra_kwargs = parse_extra_keywords(override_kwargs_str)
+    extra_kwargs = {}
+    extra_kwargs.update(kwargs)
+
+    return ContextOverride(
+        # window=window,
+        # screen=screen,
+        area=area,
+        region=region,
+        extra=extra_kwargs,
+    )
 
 
 def get_override_args(
     area: Union[str, bpy.types.Area] = None,
     region: Union[str, bpy.types.Region] = "WINDOW",
     screen: Union[str, bpy.types.Screen] = None,
-    window: bpy.types.Window = None,
+    window: Union[str, bpy.types.Window] = None,
+    # override_kwargs_str: str = "",
+    extra_priority: bool = False,
+    delete_none: bool = True,
     **kwargs,
-):
-    """Get the override context arguments"""
-    window = window or bpy.context.window
-    screen = screen or bpy.context.screen
-
-    area = find_area(area, screen)
-    region = find_region(region, area)
-
-    override_args = {
-        "area": area,
-        "region": region,
-        "screen": screen,
-        "window": window,
-        "blend_data": bpy.context.blend_data,
-    }
-
-    override_args.update(kwargs)
-    override_args = {k: v for k, v in override_args.items() if v is not None}
-
-    return override_args
+) -> dict:
+    cov = create_context_override(
+        area=area,
+        region=region,
+        screen=screen,
+        window=window,
+        # override_kwargs_str=override_kwargs_str,
+        **kwargs,
+    )
+    return cov.validate(bpy.context, extra_priority=extra_priority, delete_none=delete_none)
 
 
 def focus_area(area, center=False, cmd=None):


### PR DESCRIPTION
# Replace Context Dict Overrides with `temp_override`

## Summary
This PR modernizes PME’s context override system by replacing all deprecated dictionary-based overrides with Blender’s `context.temp_override`, introduced in Blender 3.2. ( #13 )

## Changes
- **Dictionary-based context overrides** have been replaced with **`context.temp_override`**.
- Added a new **`PME_OT_exec_override`** operator to support command-line context overrides.

## Breaking Changes
- **PME now requires Blender 3.2 or later** to use `context.temp_override`.
- Removed support for **dictionary-based context overrides** from PME.

## Technical Details
- Introduced a new **`ContextOverride`** class to handle parameter validation and object resolution.
- Legacy functions **`override_context`** and **`ctx_dict`** remain temporarily for backward compatibility.
- Added **deprecation warnings** for these legacy functions.

## Future Plans
- **Remove** the deprecated **`override_context`** and **`ctx_dict`** functions after the next release if no critical issues are reported.
- Further investigate and document **historical `bl_context` usage** patterns.

## Testing
- Verified **popup area** functionality using the new system.
- Tested **example operations** (e.g., region flips) to ensure correctness with `temp_override`.