### PR TITLE
feat: Add and integrate context override features and refactoring

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -191,8 +191,8 @@ def load_pre_handler(_):
 
 
 @persistent
-def load_post_handler(_):
-    DBG_INIT and logh("Load Post (%s)" % bpy.data.filepath)
+def load_post_handler(filepath):
+    DBG_INIT and logh("Load Post (%s)" % filepath)
 
     global tmp_data
     if tmp_data is None:
@@ -206,9 +206,9 @@ def load_post_handler(_):
     tmp_data = None
 
     if pr.missing_kms:
-        bpy.ops.pme.wait_keymaps(
-            dict(window=bpy.context.window_manager.windows[0]),
-            'INVOKE_DEFAULT')
+        logw(f"Missing Keymaps: {pr.missing_kms}")
+        with bpy.context.temp_override(window=bpy.context.window_manager.windows[0]):
+            bpy.ops.pme.wait_keymaps('INVOKE_DEFAULT')
     else:
         temp_prefs().init_tags()
         pr.tree.update()
@@ -255,10 +255,9 @@ def on_context():
             m.register()
 
     if pr.missing_kms:
-        DBG_INIT and logi("%d Missing Keymaps" % len(pr.missing_kms))
-        bpy.ops.pme.wait_keymaps(
-            dict(window=bpy.context.window_manager.windows[0]),
-            'INVOKE_DEFAULT')
+        logw(f"Missing Keymaps: {pr.missing_kms}")
+        with bpy.context.temp_override(window=bpy.context.window_manager.windows[0]):
+            bpy.ops.pme.wait_keymaps('INVOKE_DEFAULT')
 
     else:
         compatibility_fixes.fix()

--- a/__init__.py
+++ b/__init__.py
@@ -5,8 +5,9 @@ bl_info = {
     "blender": (2, 80, 0),
     "warning": "",
     "tracker_url": "http://blenderartists.org/forum/showthread.php?392910",
-    "wiki_url": (
-        "https://en.blender.org/index.php/User:Raa/Addons/Pie_Menu_Editor"),
+    # "wiki_url": (
+    #     "https://archive.blender.org/wiki/2015/index.php/User:Raa/Addons/Pie_Menu_Editor/"),
+    "doc_url": "https://pluglug.github.io/pme-docs",
     "category": "User Interface"
 }
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,8 +1,8 @@
 bl_info = {
     "name": "Pie Menu Editor",
-    "author": "roaoao",
-    "version": (1, 18, 7),
-    "blender": (2, 80, 0),
+    "author": "roaoao, pluglug",
+    "version": (1, 18, 8),
+    "blender": (3, 2, 0),
     "warning": "",
     "tracker_url": "http://blenderartists.org/forum/showthread.php?392910",
     # "wiki_url": (

--- a/addon.py
+++ b/addon.py
@@ -40,8 +40,8 @@ def check_context():
 
 
 def print_exc(text=None):
-    # if not prefs().debug_mode:
-    #     return
+    if not prefs().show_error_trace:
+        return
 
     if text is not None:
         print()

--- a/addon.py
+++ b/addon.py
@@ -40,8 +40,8 @@ def check_context():
 
 
 def print_exc(text=None):
-    if not prefs().debug_mode:
-        return
+    # if not prefs().debug_mode:
+    #     return
 
     if text is not None:
         print()

--- a/addon.py
+++ b/addon.py
@@ -55,6 +55,8 @@ def is_28():
 
 
 def ic(icon):
+    # Legacy_TODO: Remove or Enhance
+    # Support for 2.79 and 2.8+
     if not icon:
         return icon
 
@@ -76,6 +78,7 @@ def ic(icon):
     if icon in bl28_icons and bl28_icons[icon] in ICON_ENUM_ITEMS:
         return bl28_icons[icon]
 
+    print("Icon not found:", icon)
     return 'BLENDER'
 
 

--- a/bl_utils.py
+++ b/bl_utils.py
@@ -796,15 +796,29 @@ def ctx_dict(
 
 
 def area_header_text_set(text=None, area=None):
-    if not area:
+    if area is None:
         area = bpy.context.area
 
-    if text:
-        area.header_text_set(text=text)
-    elif is_28():
-        area.header_text_set(text=None)
+    if area is None:
+        # Note: bpy.context.area becomes None during modal execution if `screen.screen_full_area` is called.
+        areas = _find_areas_with_header_text_support(bpy.context)
+        if not areas:
+            logw("area_header_text_set", "No valid areas with 'header_text_set' available in current context. Exiting function.")
+            return
     else:
-        area.header_text_set()
+        areas = [area]
+
+    for area in areas:
+        if text:
+            area.header_text_set(text=text)
+        elif is_28():
+            area.header_text_set(text=None)
+        else:
+            area.header_text_set()
+
+
+def _find_areas_with_header_text_support(context):
+    return [area for area in context.screen.areas if hasattr(area, 'header_text_set')]
 
 
 # FIXME: Width and Height are not actually applied.

--- a/bl_utils.py
+++ b/bl_utils.py
@@ -2,10 +2,11 @@ import bpy
 import _bpy
 import re
 from .addon import print_exc, ic, uprefs, is_28
-from .debug_utils import *
+from .screen_utils import get_override_args
 from . import constants as CC
 from . import pme
 from . import c_utils
+from .debug_utils import *
 
 cdll = None
 
@@ -759,38 +760,39 @@ def get_space_data(area_type):
     return ret
 
 
-def get_context_data(area_type):
-    ret = dict()
-    ret["space_data"] = get_space_data(area_type)
-    return ret
+# def get_context_data(area_type):  # B4.0: Replace dictionary override with context.temp_override
+#     ret = dict()
+#     ret["space_data"] = get_space_data(area_type)
+#     return ret
 
 
+# MIGRATION_TODO: Replace dictionary override with context.temp_override
 def ctx_dict(
         window=None, screen=None, area=None, region=None, scene=None,
         workspace=None):
-    if window:
-        screen = screen or window.screen
-        workspace = workspace or window.workspace
-        area = area or screen.areas[0]
-        if region is None:
-            for r in area.regions:
-                if r.type == 'WINDOW':
-                    region = r
-                    break
-            else:
-                region = area.regions[0]
+    import warnings
+    warnings.warn(
+        "ctx_dict() is deprecated, use get_override_args() instead",
+        DeprecationWarning, stacklevel=2)
 
-        if bpy.app.version < (2, 80, 0):
-            scene = scene or screen.scene
+    d = get_override_args(area=area, region=region, screen=screen,
+                window=window, scene=scene, workspace=workspace)
 
-    return dict(
-        window=window or bl_context.window,
-        workspace=workspace or bl_context.workspace,
-        screen=screen or bl_context.screen,
-        area=area or bl_context.area,
-        region=region or bl_context.region,
-        scene=scene or bl_context.scene,
-    )
+    # default_kwargs = {
+    #     "window": bl_context.window,
+    #     "screen": bl_context.screen,
+    #     "area": bl_context.area,
+    #     "region": bl_context.region,
+    #     "scene": bl_context.scene,
+    #     "workspace": bl_context.workspace,
+    # }
+
+    # # MIGRATION_TODO:  Investigate the need for bl_context here and make sure to remove it.
+    # for k, v in default_kwargs.items():
+    #     if k not in d:
+    #         d[k] = v
+
+    return d
 
 
 def area_header_text_set(text=None, area=None):
@@ -805,6 +807,7 @@ def area_header_text_set(text=None, area=None):
         area.header_text_set()
 
 
+# FIXME: Width and Height are not actually applied.
 def popup_area(area, width=320, height=400, x=None, y=None):
     r = c_utils.area_rect(area)
 
@@ -829,7 +832,8 @@ def popup_area(area, width=320, height=400, x=None, y=None):
     upr.view.ui_scale = 1
     upr.view.ui_line_width = 'THIN'
 
-    bpy.ops.screen.area_dupli(ctx_dict(area=area), 'INVOKE_DEFAULT')
+    with C.temp_override(**ctx_dict(area=area)):  # MIGRATION_TODO: Delete ctx_dict
+        bpy.ops.screen.area_dupli('INVOKE_DEFAULT')
 
     upr.view.ui_scale = ui_scale
     upr.view.ui_line_width = ui_line_width
@@ -859,4 +863,4 @@ def register():
     pme.context.add_global("message_box", message_box)
     pme.context.add_global("input_box", input_box)
     pme.context.add_global("close_popups", close_popups)
-    pme.context.add_global("ctx", get_context_data)
+    # pme.context.add_global("ctx", get_context_data)

--- a/collection_utils.py
+++ b/collection_utils.py
@@ -106,7 +106,7 @@ class MoveItemOperator:
         return None
 
     def get_icon(self, item, idx):
-        return 'SPACE2' if idx == self.old_idx else 'SPACE3'
+        return 'KEYTYPE_KEYFRAME_VEC' if idx == self.old_idx else 'HANDLETYPE_FREE_VEC'
 
     def get_title(self):
         return "Move Item"

--- a/constants.py
+++ b/constants.py
@@ -250,7 +250,7 @@ def area_type_enum_items(current=True, none=False):
         ei.add_item('CURRENT', "Current", 'BLENDER')
 
     if none:
-        ei.add_item('NONE', "None", 'SPACE3')
+        ei.add_item('NONE', "None", 'HANDLETYPE_FREE_VEC')
 
     ei.add_item('VIEW_3D', "3D View", 'VIEW3D')
     ei.add_item('TIMELINE', "Timeline", 'TIME')
@@ -268,10 +268,10 @@ def area_type_enum_items(current=True, none=False):
     ei.add_item('GeometryNodeTree', "Geometry Node Editor", 'NODETREE')
     ei.add_item('TEXT_EDITOR', "Text Editor", 'TEXT')
     ei.add_item('PROPERTIES', "Properties", 'PROPERTIES')
-    ei.add_item('OUTLINER', "Outliner", 'OOPS')
+    ei.add_item('OUTLINER', "Outliner", 'OUTLINER')
     ei.add_item(UPREFS, "User Preferences", 'PREFERENCES')
     ei.add_item('INFO', "Info", 'INFO')
-    ei.add_item('FILE_BROWSER', "File Browser", 'FILESEL')
+    ei.add_item('FILE_BROWSER', "File Browser", 'FILEBROWSER')
     ei.add_item('ASSETS', "Asset Browser", 'ASSET_MANAGER')
     ei.add_item('SPREADSHEET', "Spreadsheet", 'SPREADSHEET')
     ei.add_item('CONSOLE', "Python Console", 'CONSOLE')

--- a/ed_base.py
+++ b/ed_base.py
@@ -731,17 +731,19 @@ class WM_OT_pmi_edit_auto(bpy.types.Operator):
         return {'FINISHED'}
 
     def invoke(self, context, event):
-        ctx = find_context('INFO')
-        area_type = not ctx and context.area.type
-        args = []
-        if ctx:
-            args.append(ctx)
-        else:
+        info_area = SU.find_area("INFO")
+        if not info_area:
+            old_type = context.area.type
             context.area.type = 'INFO'
+        
+        override_args = SU.get_override_args(area="INFO")
 
         bpy.ops.wm.pme_none()
-        bpy.ops.info.select_all(*args, action='SELECT')
-        bpy.ops.info.report_copy(*args)
+
+        with bpy.context.temp_override(**override_args):
+            bpy.ops.info.select_all(action='SELECT')
+            bpy.ops.info.report_copy()
+
         text = context.window_manager.clipboard
 
         idx2 = len(text)
@@ -761,14 +763,15 @@ class WM_OT_pmi_edit_auto(bpy.types.Operator):
                 text = line
                 break
 
-        bpy.ops.info.select_all(*args, action='DESELECT')
+        with bpy.context.temp_override(**override_args):
+            bpy.ops.info.select_all(action='DESELECT')
 
         text = text.strip("\n")
 
         _edit_pmi(self, text, event)
 
-        if area_type:
-            context.area.type = area_type
+        if not info_area:
+            context.area.type = old_type
 
         return {'CANCELLED'}
 
@@ -1201,6 +1204,11 @@ class PME_OT_pmi_cmd_generate(bpy.types.Operator):
         if pr.mode == 'PMI' and data.mode in CC.MODAL_CMD_MODES:
             op_idname, _, pos_args = operator_utils.find_operator(data.cmd)
 
+            parsed_ctx, parsed_undo = operator_utils.parse_pos_args(pos_args)
+
+            C_exec = data.cmd_ctx or parsed_ctx
+            C_undo = data.cmd_undo if (data.cmd_undo is not None) else parsed_undo
+
             args = []
             for k in data.kmi.properties.keys():
                 v = getattr(data.kmi.properties, k)
@@ -1209,25 +1217,18 @@ class PME_OT_pmi_cmd_generate(bpy.types.Operator):
                     continue
                 args.append("%s=%s" % (k, repr(value)))
 
-            if len(pos_args) > 3:
-                pos_args.clear()
+            pos_args_new = []
 
-            pos_args = [pos_args[0]] \
-                if pos_args and isinstance(eval(pos_args[0]), dict) \
-                else []
-            if data.cmd_ctx == 'INVOKE_DEFAULT':
-                if not data.cmd_undo:
-                    pos_args.append(repr(data.cmd_undo))
+            if C_exec == 'INVOKE_DEFAULT':
+                if not C_undo:
+                    pos_args_new.append(repr(C_undo))
             else:
-                pos_args.append(repr(data.cmd_ctx))
-                if data.cmd_undo:
-                    pos_args.append(repr(data.cmd_undo))
+                pos_args_new.append(repr(C_exec))
+                if C_undo:
+                    pos_args_new.append(repr(C_undo))
 
-            if pos_args and args:
-                pos_args.append("")
-
-            cmd = "bpy.ops.%s(%s%s)" % (
-                op_idname, ", ".join(pos_args), ", ".join(args))
+            call_args = ", ".join(pos_args_new + args)
+            cmd = f"bpy.ops.{op_idname}({call_args})"
 
             if DBG_CMD_EDITOR:
                 data.cmd = cmd

--- a/ed_base.py
+++ b/ed_base.py
@@ -202,7 +202,7 @@ class PME_OT_tags(bpy.types.Operator):
             layout.separator()
 
         operator(
-            layout, PME_OT_tags.bl_idname, "Assign New Tag", 'ZOOMIN',
+            layout, PME_OT_tags.bl_idname, "Assign New Tag", 'ADD',
             action='ADD', group=self.group)
 
         if self.action != 'MENU':
@@ -216,7 +216,7 @@ class PME_OT_tags(bpy.types.Operator):
             'OUTLINER_DATA_FONT',
             action='RENAME')
         operator(
-            layout, PME_OT_tags.bl_idname, "Remove Tag", 'ZOOMOUT',
+            layout, PME_OT_tags.bl_idname, "Remove Tag", 'REMOVE',
             action='REMOVE')
 
     def draw(self, context):
@@ -290,7 +290,7 @@ class PME_OT_tags(bpy.types.Operator):
         elif self.action == 'REMOVE':
             if self.idx == -1:
                 context.window_manager.popup_menu(
-                    self.draw_menu, title="Remove Tag", icon='ZOOMOUT')
+                    self.draw_menu, title="Remove Tag", icon='REMOVE')
             else:
                 for pm in pr.pie_menus:
                     pm.remove_tag(tag.name)
@@ -891,7 +891,7 @@ class PME_OT_pm_edit(bpy.types.Operator):
             if pmi.mode == 'EMPTY':
                 if pmi.text == "column":
                     lh.operator(
-                        self.op_bl_idname, "Add Item", 'ZOOMIN',
+                        self.op_bl_idname, "Add Item", 'ADD',
                         pm_item=idx,
                         mode=self.mode, text=self.text, name=self.name,
                         add=True, new_script=False)
@@ -918,7 +918,7 @@ class PME_OT_pm_edit(bpy.types.Operator):
                 add=False, new_script=False)
 
         lh.operator(
-            self.op_bl_idname, "Add Item", 'ZOOMIN',
+            self.op_bl_idname, "Add Item", 'ADD',
             pm_item=-1, mode=self.mode, text=self.text, name=self.name,
             add=True, new_script=False)
 
@@ -959,7 +959,7 @@ class PME_OT_pm_edit(bpy.types.Operator):
         draw_pme_layout(pm, col, draw_pmi)
 
         operator(
-            column, self.op_bl_idname, "Add New Row", 'ZOOMIN',
+            column, self.op_bl_idname, "Add New Row", 'ADD',
             pm_item=-1, mode=self.mode, name=self.name,
             add=True, new_script=False).text = self.text
 
@@ -976,7 +976,7 @@ class PME_OT_pm_edit(bpy.types.Operator):
                 add=False, new_script=False)
 
         lh.operator(
-            self.op_bl_idname, "New Command", 'ZOOMIN',
+            self.op_bl_idname, "New Command", 'ADD',
             pm_item=-1, mode=self.mode, text=self.text, name=self.name,
             add=True, new_script=False)
 
@@ -2206,13 +2206,13 @@ class EditorBase:
     def draw_keymap(self, layout, data):
         row = layout.row(align=True)
         if ',' in data.km_name:
-            row.prop(data, "km_name", text="", icon=ic('SPLITSCREEN'))
+            row.prop(data, "km_name", text="", icon=ic('MOUSE_MMB'))
         else:
             row.prop_search(
                 data, "km_name",
                 bpy.context.window_manager.keyconfigs.user, "keymaps",
-                text="", icon=ic('SPLITSCREEN'))
-        row.operator(PME_OT_keymap_add.bl_idname, text="", icon=ic('ZOOMIN'))
+                text="", icon=ic('MOUSE_MMB'))
+        row.operator(PME_OT_keymap_add.bl_idname, text="", icon=ic('ADD'))
 
     def draw_hotkey(self, layout, data):
         row = layout.row(align=True)
@@ -2329,7 +2329,7 @@ class EditorBase:
 
         if not self.fixed_num_items:
             lh.operator(
-                PME_OT_pmi_add.bl_idname, "Add Slot", 'ZOOMIN',
+                PME_OT_pmi_add.bl_idname, "Add Slot", 'ADD',
                 idx=idx)
 
         if self.copy_paste_slot:
@@ -2406,7 +2406,7 @@ class EditorBase:
         lh.sep()
 
         lh.operator(
-            self.op.op_bl_idname, "New Command", 'ZOOMIN',
+            self.op.op_bl_idname, "New Command", 'ADD',
             mode=self.op.mode, text=self.op.text, name=self.op.name,
             pm_item=-1, add=True, new_script=False)
 

--- a/ed_hpanel_group.py
+++ b/ed_hpanel_group.py
@@ -16,9 +16,9 @@ class PME_OT_hpanel_menu(bpy.types.Operator):
         pr = prefs()
         lh.lt(menu.layout, 'INVOKE_DEFAULT')
         lh.operator(
-            PME_OT_panel_hide.bl_idname, None, 'ZOOMIN',
+            PME_OT_panel_hide.bl_idname, None, 'ADD',
             group=pr.selected_pm.name)
-        lh.operator(PME_OT_panel_hide_by.bl_idname, None, 'ZOOMIN')
+        lh.operator(PME_OT_panel_hide_by.bl_idname, None, 'ADD')
         lh.sep()
 
         lh.prop(pr, "interactive_panels")
@@ -106,11 +106,11 @@ class Editor(EditorBase):
             pm, "pmis", tpr, "hidden_panels_idx", rows=10)
 
         lh.column(row)
-        lh.operator(PME_OT_hpanel_menu.bl_idname, "", 'ZOOMIN')
+        lh.operator(PME_OT_hpanel_menu.bl_idname, "", 'ADD')
 
         if len(pm.pmis):
             lh.operator(
-                PME_OT_hpanel_remove.bl_idname, "", 'ZOOMOUT',
+                PME_OT_hpanel_remove.bl_idname, "", 'REMOVE',
                 idx=tpr.hidden_panels_idx)
             lh.operator(
                 PME_OT_hpanel_remove.bl_idname, "", 'X', idx=-1)

--- a/ed_menu.py
+++ b/ed_menu.py
@@ -68,7 +68,7 @@ class WM_OT_rmi_move(bpy.types.Operator):
         for idx, pmi in enumerate(pm.pmis):
             name = pmi.name
             # icon = pmi.parse_icon()
-            icon = 'SPACE2' if idx == self.pm_item else 'SPACE3'
+            icon = 'KEYTYPE_KEYFRAME_VEC' if idx == self.pm_item else 'HANDLETYPE_FREE_VEC'
 
             if pmi.mode == 'EMPTY':
                 if pmi.text == "column":
@@ -131,29 +131,29 @@ class WM_OT_rm_col_specials_call(bpy.types.Operator):
         lh.lt(menu.layout, operator_context='INVOKE_DEFAULT')
 
         lh.operator(
-            WM_OT_rmi_add.bl_idname, "Add Column", 'ZOOMIN',
+            WM_OT_rmi_add.bl_idname, "Add Column", 'ADD',
             index=self.cur_col.a,
             mode='COLUMN')
 
         lh.sep(check=True)
 
         lh.operator(
-            WM_OT_rmi_add.bl_idname, "Add Slot", 'ZOOMIN',
+            WM_OT_rmi_add.bl_idname, "Add Slot", 'ADD',
             index=self.cur_col.b,
             mode='ITEM')
 
         lh.operator(
-            WM_OT_rmi_add.bl_idname, "Add Label", 'ZOOMIN',
+            WM_OT_rmi_add.bl_idname, "Add Label", 'ADD',
             index=self.cur_col.b,
             mode='LABEL')
 
         lh.operator(
-            WM_OT_rmi_add.bl_idname, "Add Separator", 'ZOOMIN',
+            WM_OT_rmi_add.bl_idname, "Add Separator", 'ADD',
             index=self.cur_col.b,
             mode='SEPARATOR')
 
         lh.operator(
-            WM_OT_rmi_add.bl_idname, "Add Spacer", 'ZOOMIN',
+            WM_OT_rmi_add.bl_idname, "Add Spacer", 'ADD',
             index=self.cur_col.b,
             mode='SPACER')
 
@@ -232,7 +232,7 @@ class WM_OT_rm_col_move(bpy.types.Operator):
         lh.lt(menu.layout)
 
         for idx, col in enumerate(WM_OT_rm_col_move.cols):
-            icon = 'SPACE2' if self.col_idx == col[1] else 'SPACE3'
+            icon = 'KEYTYPE_KEYFRAME_VEC' if self.col_idx == col[1] else 'HANDLETYPE_FREE_VEC'
             lh.operator(
                 WM_OT_rm_col_move.bl_idname, "Column %d" % (idx + 1), icon,
                 move_idx=idx,
@@ -465,22 +465,22 @@ class WM_OT_rmi_specials_call(bpy.types.Operator):
         lh.sep(check=True)
 
         lh.operator(
-            WM_OT_rmi_add.bl_idname, "Add Slot", 'ZOOMIN',
+            WM_OT_rmi_add.bl_idname, "Add Slot", 'ADD',
             index=self.pm_item,
             mode='ITEM')
 
         lh.operator(
-            WM_OT_rmi_add.bl_idname, "Add Label", 'ZOOMIN',
+            WM_OT_rmi_add.bl_idname, "Add Label", 'ADD',
             index=self.pm_item,
             mode='LABEL')
 
         lh.operator(
-            WM_OT_rmi_add.bl_idname, "Add Separator", 'ZOOMIN',
+            WM_OT_rmi_add.bl_idname, "Add Separator", 'ADD',
             index=self.pm_item,
             mode='SEPARATOR')
 
         lh.operator(
-            WM_OT_rmi_add.bl_idname, "Add Spacer", 'ZOOMIN',
+            WM_OT_rmi_add.bl_idname, "Add Spacer", 'ADD',
             index=self.pm_item,
             mode='SPACER')
 
@@ -687,7 +687,7 @@ class Editor(EditorBase):
         row.scale_y = max_scale_y + 1
 
         lh.operator(
-            WM_OT_rmi_add.bl_idname, "", 'ZOOMIN',
+            WM_OT_rmi_add.bl_idname, "", 'ADD',
             index=-1,
             mode='COLUMN')
 

--- a/ed_panel_group.py
+++ b/ed_panel_group.py
@@ -59,10 +59,10 @@ class PME_OT_toolbar_menu(bpy.types.Operator):
         dir_name = def_name + " " + dir_name
 
         lh.operator(
-            self.bl_idname, "Create Toolbar (Current Screen)", 'ZOOMIN',
+            self.bl_idname, "Create Toolbar (Current Screen)", 'ADD',
             name=dir_scr_name)
         lh.operator(
-            self.bl_idname, "Create Toolbar (All Screens)", 'ZOOMIN',
+            self.bl_idname, "Create Toolbar (All Screens)", 'ADD',
             name=dir_name)
 
     def execute(self, context):
@@ -261,7 +261,7 @@ class PME_OT_panel_menu(bpy.types.Operator):
             if pm.mode in {'PMENU', 'RMENU', 'DIALOG'}:
                 lh.operator(
                     PME_OT_pm_edit.bl_idname, "Add as Menu to '%s'" % pm.name,
-                    'ZOOMIN',
+                    'ADD',
                     auto=False,
                     name=label, mode='CUSTOM',
                     text="L.menu(menu='%s', text=slot, icon=icon, "
@@ -311,7 +311,7 @@ class PME_OT_panel_menu(bpy.types.Operator):
                 lh.operator(
                     PME_OT_pm_edit.bl_idname,
                     "Add as Button to '%s'" % pm.name,
-                    'ZOOMIN',
+                    'ADD',
                     auto=False,
                     name=label, mode='COMMAND',
                     text=(
@@ -323,7 +323,7 @@ class PME_OT_panel_menu(bpy.types.Operator):
                     lh.operator(
                         PME_OT_pm_edit.bl_idname,
                         "Add as Popover to '%s'" % pm.name,
-                        'ZOOMIN',
+                        'ADD',
                         auto=False,
                         name=label, mode='CUSTOM',
                         text=(
@@ -336,19 +336,19 @@ class PME_OT_panel_menu(bpy.types.Operator):
                 lh.operator(
                     PME_OT_panel_add.bl_idname,
                     "Add as Panel to '%s'" % pm.name,
-                    'ZOOMIN',
+                    'ADD',
                     panel=self.panel, mode='BLENDER')
 
             elif pm.mode == 'DIALOG':
                 lh.operator(
                     PME_OT_panel_add.bl_idname,
-                    "Add as Panel to '%s'" % pm.name, 'ZOOMIN',
+                    "Add as Panel to '%s'" % pm.name, 'ADD',
                     panel=self.panel, mode='DIALOG')
 
             elif pm.mode == 'PMENU':
                 lh.operator(
                     PME_OT_pm_edit.bl_idname,
-                    "Add as Panel to '%s'" % pm.name, 'ZOOMIN',
+                    "Add as Panel to '%s'" % pm.name, 'ADD',
                     auto=False,
                     name=label, mode='CUSTOM',
                     text="panel('%s', area='%s')" % (
@@ -778,7 +778,7 @@ class Editor(EditorBase):
         lh.sep(check=True)
 
         lh.operator(
-            PME_OT_panel_add.bl_idname, "Add Panel", 'ZOOMIN',
+            PME_OT_panel_add.bl_idname, "Add Panel", 'ADD',
             index=idx)
 
         if len(pm.pmis) > 1:

--- a/ed_popup.py
+++ b/ed_popup.py
@@ -552,7 +552,7 @@ class PME_OT_pdr_move(bpy.types.Operator, MoveItemOperator):
         prev_p = None
         for i, pmi in enumerate(pm.pmis):
             if pmi.mode == 'EMPTY' and pmi.text.startswith("row"):
-                icon = 'SPACE2' if self.old_idx == i else 'SPACE3'
+                icon = 'KEYTYPE_KEYFRAME_VEC' if self.old_idx == i else 'HANDLETYPE_FREE_VEC'
                 new_idx = i
 
                 p = lh.operator(
@@ -571,14 +571,14 @@ class PME_OT_pdr_move(bpy.types.Operator, MoveItemOperator):
 
         # idx = 0
         # for idx, row in enumerate(PME_OT_pdr_move.rows):
-        #     icon = 'SPACE2' if self.row_idx == row[0] else 'SPACE3'
+        #     icon = 'KEYTYPE_KEYFRAME_VEC' if self.row_idx == row[0] else 'HANDLETYPE_FREE_VEC'
         #     lh.operator(
         #         PME_OT_pdr_move.bl_idname, "Row %d" % (idx + 1), icon,
         #         move_idx=idx,
         #         row_idx=self.row_idx)
 
         # lh.operator(
-        #     PME_OT_pdr_move.bl_idname, ". . .", 'SPACE3',
+        #     PME_OT_pdr_move.bl_idname, ". . .", 'HANDLETYPE_FREE_VEC',
         #     move_idx=idx + 1,
         #     row_idx=self.row_idx)
 
@@ -835,8 +835,8 @@ class PME_MT_pdr_alignment(bpy.types.Menu):
         for item in pme.props.get("align").items:
             lh.operator(
                 PME_OT_pdr_prop_set.bl_idname, item[1],
-                'SPACE2' if pp.parse(
-                    row.text).align == item[0] else 'SPACE3',
+                'KEYTYPE_KEYFRAME_VEC' if pp.parse(
+                    row.text).align == item[0] else 'HANDLETYPE_FREE_VEC',
                 mode='ROW',
                 prop="align",
                 value=item[0])
@@ -856,7 +856,7 @@ class PME_MT_pdr_alignment(bpy.types.Menu):
         # for item in pme.props.get("align").items:
         #     lh.operator(
         #         PME_OT_pdr_prop_set.bl_idname, item[1],
-        #         'SPACE3',
+        #         'HANDLETYPE_FREE_VEC',
         #         mode='ALIGN_ROWS',
         #         prop="align",
         #         value=item[0])
@@ -868,7 +868,7 @@ class PME_MT_pdr_alignment(bpy.types.Menu):
         # for item in pme.props.get("align").items:
         #     lh.operator(
         #         PME_OT_pdr_prop_set.bl_idname, item[1],
-        #         'SPACE3',
+        #         'HANDLETYPE_FREE_VEC',
         #         mode='ALL_ROWS',
         #         prop="align",
         #         value=item[0])
@@ -887,13 +887,13 @@ class PME_MT_pdr_size(bpy.types.Menu):
 
         lh.save()
         lh.column()
-        lh.label("Row", icon='ZOOMOUT')
+        lh.label("Row", icon='REMOVE')
         lh.sep()
         for item in pme.props.get("size").items:
             lh.operator(
                 PME_OT_pdr_prop_set.bl_idname, item[1],
-                'SPACE2' if pp.parse(
-                    row.text).size == item[0] else 'SPACE3',
+                'KEYTYPE_KEYFRAME_VEC' if pp.parse(
+                    row.text).size == item[0] else 'HANDLETYPE_FREE_VEC',
                 mode='ROW',
                 prop="size",
                 value=item[0])
@@ -906,7 +906,7 @@ class PME_MT_pdr_size(bpy.types.Menu):
         for item in pme.props.get("size").items:
             lh.operator(
                 PME_OT_pdr_prop_set.bl_idname, item[1],
-                'SPACE3',
+                'HANDLETYPE_FREE_VEC',
                 mode='ALIGN_ROWS',
                 prop="size",
                 value=item[0])
@@ -918,7 +918,7 @@ class PME_MT_pdr_size(bpy.types.Menu):
         for item in pme.props.get("size").items:
             lh.operator(
                 PME_OT_pdr_prop_set.bl_idname, item[1],
-                'SPACE3',
+                'HANDLETYPE_FREE_VEC',
                 mode='ALL_ROWS',
                 prop="size",
                 value=item[0])
@@ -936,7 +936,7 @@ class PME_MT_pdr_spacer(bpy.types.Menu):
 
         lh.save()
         lh.column()
-        lh.label("Row", icon='ZOOMOUT')
+        lh.label("Row", icon='REMOVE')
         lh.sep()
 
         for item in pme.props.get("vspacer").items:
@@ -945,8 +945,8 @@ class PME_MT_pdr_spacer(bpy.types.Menu):
                 continue
             lh.operator(
                 PME_OT_pdr_prop_set.bl_idname, item[1],
-                'SPACE2' if pme.props.parse(
-                    row.text).vspacer == item[0] else 'SPACE3',
+                'KEYTYPE_KEYFRAME_VEC' if pme.props.parse(
+                    row.text).vspacer == item[0] else 'HANDLETYPE_FREE_VEC',
                 mode='ROW',
                 prop="vspacer",
                 value=item[0])
@@ -958,7 +958,7 @@ class PME_MT_pdr_spacer(bpy.types.Menu):
         for item in pme.props.get("vspacer").items:
             lh.operator(
                 PME_OT_pdr_prop_set.bl_idname, item[1],
-                'SPACE3',
+                'HANDLETYPE_FREE_VEC',
                 mode='ALL_ROWS',
                 prop="vspacer",
                 value=item[0])
@@ -975,11 +975,11 @@ class PME_MT_pdr_spacer(bpy.types.Menu):
 #         lh.lt(self.layout)
 
 #         for item in pme.props.get("hsep").items:
-#             icon = 'SPACE3'
+#             icon = 'HANDLETYPE_FREE_VEC'
 #             if prev_pmi.mode == 'EMPTY' and \
 #                     pp.parse(prev_pmi.text).hsep == item[0] or \
 #                     prev_pmi.mode != 'EMPTY' and item[0] == 'NONE':
-#                 icon = 'SPACE2'
+#                 icon = 'KEYTYPE_KEYFRAME_VEC'
 
 #             lh.operator(
 #                 PME_OT_pdr_prop_set.bl_idname, item[1], icon,
@@ -1460,13 +1460,13 @@ class PME_OT_pdr_menu(bpy.types.Operator):
         lh.sep(check=True)
 
         lh.operator(
-            PME_OT_pdi_add.bl_idname, "Add Row Above", 'ZOOMIN',
+            PME_OT_pdi_add.bl_idname, "Add Row Above", 'ADD',
             row_idx=self.row_idx,
             idx=self.row_idx,
             mode='ROW')
 
         lh.operator(
-            PME_OT_pdi_add.bl_idname, "Add Row Below", 'ZOOMIN',
+            PME_OT_pdi_add.bl_idname, "Add Row Below", 'ADD',
             row_idx=self.row_idx,
             idx=self.row_last_idx,
             mode='ROW')

--- a/ed_property.py
+++ b/ed_property.py
@@ -1123,7 +1123,7 @@ class Editor(EditorBase):
                 if pmi.mode == 'PROP':
                     self.draw_enum_item(pm, pmi, i)
 
-            lh.operator(PME_OT_pmi_add.bl_idname, "Add Slot", 'ZOOMIN')
+            lh.operator(PME_OT_pmi_add.bl_idname, "Add Slot", 'ADD')
 
         lh.box(layout)
         col = lh.column()

--- a/examples/window_area_pie.json
+++ b/examples/window_area_pie.json
@@ -24,14 +24,14 @@
           "Header", 
           "COMMAND", 
           "TRIA_DOWN", 
-          "r = C.area.regions[0]; sd = C.space_data; on_top = r.y > C.area.y; bpy.ops.screen.region_flip(dict(region=r)) if on_top else None; sd.show_region_header = on_top or not sd.show_region_header", 
+          "r = C.area.regions[0]; sd = C.space_data; on_top = r.y > C.area.y; O.pme.exec_override(cmd='O.screen.region_flip()', kwargs='d=dict(region=C.area.regions[0])') if on_top else None; sd.show_region_header = on_top or not sd.show_region_header",
           0
         ], 
         [
           "Header", 
           "COMMAND", 
           "TRIA_UP", 
-          "r = C.area.regions[0]; sd = C.space_data; on_top = r.y > C.area.y; bpy.ops.screen.region_flip(dict(region=r)) if not on_top else None; sd.show_region_header = not on_top or not sd.show_region_header", 
+          "r = C.area.regions[0]; sd = C.space_data; on_top = r.y > C.area.y; O.pme.exec_override(cmd='O.screen.region_flip()', kwargs='d=dict(region=C.area.regions[0])') if not on_top else None; sd.show_region_header = not on_top or not sd.show_region_header",
           0
         ], 
         [

--- a/extra_operators.py
+++ b/extra_operators.py
@@ -383,6 +383,9 @@ class PME_OT_window_auto_close(bpy.types.Operator):
     bl_options = {'INTERNAL'}
 
     def execute(self, context):
+        # Refactor_TODO: Revisit roaoao's original code and consider refactoring it.
+        #                If you do ctx_override, use temp_override
+
         # if context.window.screen.name.startswith(PME_SCREEN) or \
         #         context.window.screen.name.startswith(PME_TEMP_SCREEN):
         #     bpy.ops.wm.window_close(dict(window=context.window))
@@ -397,13 +400,16 @@ class PME_OT_window_auto_close(bpy.types.Operator):
             # used_pme_screens = set()
             for w in wm.windows:
                 if w.screen.name.startswith(PME_TEMP_SCREEN):
-                    bpy.ops.screen.new(dict(window=w))
+                    with context.temp_override(window=w):
+                        bpy.ops.screen.new()
+
                     bpy.ops.pme.timeout(
-                        cmd="p = %d; "
-                        "w = [w for w in C.window_manager.windows "
-                        "if w.as_pointer() == p][0]; "
-                        "bpy.ops.wm.window_close(dict(window=w)); "
-                        % w.as_pointer())
+                        cmd="bpy.ops.pme.exec_override("
+                            "cmd='bpy.ops.wm.window_close()', "
+                            "kwargs='p={}; "
+                            "w=[w for w in C.window_manager.windows "
+                            "if w.as_pointer() == p][0]; "
+                            "d=dict(window=w)')".format(w.as_pointer()))
 
                 # elif w.screen.name.startswith(PME_SCREEN):
                 #     used_pme_screens.add(w.screen.name)
@@ -471,7 +477,9 @@ class PME_OT_area_move(bpy.types.Operator):
             self.report({'WARNING'}, "Main area not found")
             return {'CANCELLED'}
 
-        bpy.ops.view2d.scroll_up(SU.override_context(a))
+        with context.temp_override(area=a):
+            bpy.ops.view2d.scroll_up()
+
         return {'FINISHED'}
 
         mx, my = event.mouse_x, event.mouse_y
@@ -617,10 +625,11 @@ class PME_OT_sidearea_toggle(bpy.types.Operator):
         if state[1] > 1:
             SU.toggle_sidebar(area, False, True)
 
-    def close_area(self, main, area):
+    def close_area(self, context, main, area):
         CTU.swap_spaces(area, main, self.area)
         try:
-            bpy.ops.screen.area_close(dict(area=area))
+            with context.temp_override(area=area):
+                bpy.ops.screen.area_close()
             return
         except:
             pass
@@ -698,12 +707,12 @@ class PME_OT_sidearea_toggle(bpy.types.Operator):
 
         elif l and self.side == 'LEFT' and self.action in ('TOGGLE', 'HIDE'):
             self.save_sidebars(l)
-            self.close_area(a, l)
+            self.close_area(context, a, l)
             SU.redraw_screen()
 
         elif r and self.side == 'RIGHT' and self.action in ('TOGGLE', 'HIDE'):
             self.save_sidebars(r)
-            self.close_area(a, r)
+            self.close_area(context, a, r)
             SU.redraw_screen()
 
         elif (not l and self.side == 'LEFT' or
@@ -727,11 +736,11 @@ class PME_OT_sidearea_toggle(bpy.types.Operator):
                 mouse["mouse_x"] = a.x + 1
                 mouse["mouse_y"] = a.y + 1
 
-            bpy.ops.screen.area_split(
-                SU.override_context(a),
-                direction='VERTICAL',
-                factor=factor,
-                **mouse)
+            with context.temp_override(area=a):
+                bpy.ops.screen.area_split(
+                    direction='VERTICAL',
+                    factor=factor,
+                    **mouse)
 
             new_area = context.screen.areas[-1]
             new_area.ui_type = self.area
@@ -775,21 +784,27 @@ class PME_OT_popup_area(bpy.types.Operator):
         description="Execute python code on window open",
         maxlen=MAX_STR_LEN, options={'SKIP_SAVE'})
 
-    def update_header(self, on_top, visible, d):
+    def update_header(self, context, on_top, visible, d):
         if self.header == 'DEFAULT':
             return
 
         if 'TOP' in self.header:
-            # not on_top and bpy.ops.screen.header_flip(d)
-            not on_top and bpy.ops.screen.region_flip(d)
+            if not on_top:
+                with context.temp_override(**d):
+                    bpy.ops.screen.region_flip()
         else:
-            # on_top and bpy.ops.screen.header_flip(d)
-            on_top and bpy.ops.screen.region_flip(d)
+            if on_top:
+                with context.temp_override(**d):
+                    bpy.ops.screen.region_flip()
 
         if 'HIDE' in self.header:
-            visible and bpy.ops.screen.header(d)
+            if visible:
+                with context.temp_override(**d):
+                    bpy.ops.screen.header()
         else:
-            not visible and bpy.ops.screen.header(d)
+            if not visible:
+                with context.temp_override(**d):
+                    bpy.ops.screen.header()
 
     def execute(self, context):
         return {'FINISHED'}
@@ -839,7 +854,7 @@ class PME_OT_popup_area(bpy.types.Operator):
         else:
             header_on_top = rh.y > area.y
 
-        self.update_header(header_on_top, header_visible, header_dict)
+        self.update_header(context, header_on_top, header_visible, header_dict)
 
         window = context.window
         windows = [w for w in context.window_manager.windows]
@@ -879,26 +894,27 @@ class PME_OT_popup_area(bpy.types.Operator):
 
         if new_window:
             if self.cmd:
-                getattr(bpy.ops.pme, "timeout")(
-                    ctx_dict(window=new_window),
-                    'INVOKE_DEFAULT',
-                    cmd=self.cmd)
+                pme_timeout = getattr(bpy.ops.pme, "timeout")
+                with context.temp_override(**ctx_dict(window=new_window)):  # MIGRATION_TODO: Delete ctx_dict
+                    pme_timeout('INVOKE_DEFAULT', cmd=self.cmd)
 
             new_screen_name = new_window.screen.name
+            
+            # Refactor_TODO: Double-check roaoao's original code and see if we need to reinstate it properly.
             # if screen_name in bpy.data.screens:
-            if False:
-                bpy.ops.screen.delete(
-                    dict(
-                        window=new_window,
-                        screen=bpy.data.screens[new_screen_name]))
-                bpy.ops.pme.screen_set(
-                    dict(window=new_window), name=screen_name)
+            if False:  
+                with context.temp_override(**ctx_dict(window=new_window, screen=bpy.data.screens[new_screen_name])):  # MIGRATION_TODO: Delete ctx_dict
+                    bpy.ops.screen.delete()
+
+                with context.temp_override(**ctx_dict(window=new_window)):  # MIGRATION_TODO: Delete ctx_dict
+                    bpy.ops.pme.screen_set(name=screen_name)
+
             else:
                 new_window.screen.name = screen_name
                 new_window.screen.user_clear()
 
         if new_screen_flag:
-            self.update_header(header_on_top, header_visible, header_dict)
+            self.update_header(context, header_on_top, header_visible, header_dict)
 
         if area_type:
             if is_28():

--- a/extra_operators.py
+++ b/extra_operators.py
@@ -562,18 +562,20 @@ class PME_OT_sidearea_toggle(bpy.types.Operator):
 
     def get_side_areas(self, area):
         l, r, b, t = None, None, None, None
+        # XXX: In fact, it is also affected by view.ui_scale.
+        line_width = {'AUTO': 1, 'THIN': 1, 'THICK': 3}[uprefs().view.ui_line_width]
         for a in bpy.context.screen.areas:
             if a.height == area.height and a.y == area.y and \
                     a.ui_type not in self.ia:
-                if not l and a.x + a.width + 1 == area.x:
+                if not l and a.x + a.width + line_width == area.x:
                     l = a
-                elif not r and area.x + area.width + 1 == a.x:
+                elif not r and area.x + area.width + line_width == a.x:
                     r = a
 
             if a.width == area.width and a.x == area.x:
-                if not b and a.y + a.height + 1 == area.y:
+                if not b and a.y + a.height + line_width == area.y:
                     b = a
-                elif not t and area.y + area.height + 1 == a.y:
+                elif not t and area.y + area.height + line_width == a.y:
                     t = a
 
         if b or t:

--- a/layout_helper.py
+++ b/layout_helper.py
@@ -77,17 +77,17 @@ class CLayout:
                 menu, text=text, text_ctxt=text_ctxt,
                 translate=translate, icon=ic(icon), icon_value=icon_value)
 
-        if use_mouse_over_open is True or CLayout.use_mouse_over_open is True:
-            UI_BTYPE_PULLDOWN = 27 << 9
-            c_btn = CTU.c_last_btn(c_layout)
-            c_btn.type = UI_BTYPE_PULLDOWN
-            # c_layout.root.contents.type = root_type
+        # if use_mouse_over_open is True or CLayout.use_mouse_over_open is True:
+        #     UI_BTYPE_PULLDOWN = 27 << 9
+        #     c_btn = CTU.c_last_btn(c_layout)
+        #     c_btn.type = UI_BTYPE_PULLDOWN
+        #     # c_layout.root.contents.type = root_type
 
-        elif use_mouse_over_open is False:
-            UI_BTYPE_MENU = 4 << 9
-            c_btn = CTU.c_last_btn(c_layout)
-            c_btn.type = UI_BTYPE_MENU
-            # c_layout.root.contents.type = root_type
+        # elif use_mouse_over_open is False:
+        #     UI_BTYPE_MENU = 4 << 9
+        #     c_btn = CTU.c_last_btn(c_layout)
+        #     c_btn.type = UI_BTYPE_MENU
+        #     # c_layout.root.contents.type = root_type
 
         bpy.types.UILayout.__getattribute__ = CLayout.getattribute
 

--- a/macro_utils.py
+++ b/macro_utils.py
@@ -122,7 +122,7 @@ def add_macro(pm):
                 sub_op_idname, _, pos_args = operator_utils.find_operator(
                     pmi.text)
 
-                _, sub_op_exec_ctx, _ = operator_utils.parse_pos_args(pos_args)
+                sub_op_exec_ctx, _ = operator_utils.parse_pos_args(pos_args)
 
                 if sub_op_idname and sub_op_exec_ctx.startswith('INVOKE'):
                     sub_tp = eval("bpy.ops." + sub_op_idname).idname()
@@ -201,7 +201,7 @@ def _fill_props(props, pm, idx=1):
             sub_op_idname, args, pos_args = operator_utils.find_operator(
                 pmi.text)
 
-            _, sub_op_exec_ctx, _ = operator_utils.parse_pos_args(pos_args)
+            sub_op_exec_ctx, _ = operator_utils.parse_pos_args(pos_args)
 
             if sub_op_idname and sub_op_exec_ctx.startswith('INVOKE'):
                 args = ",".join(args)

--- a/operators.py
+++ b/operators.py
@@ -68,7 +68,7 @@ class WM_OT_pm_select(bpy.types.Operator):
     def _draw(self, menu, context):
         lh.lt(menu.layout, 'INVOKE_DEFAULT')
 
-        lh.menu("PME_MT_pm_new", "New", 'ZOOMIN')
+        lh.menu("PME_MT_pm_new", "New", 'ADD')
         lh.operator(
             PME_OT_pm_search_and_select.bl_idname, None, 'VIEWZOOM',
             mode=self.mode)
@@ -90,9 +90,9 @@ class WM_OT_pm_select(bpy.types.Operator):
                 icon = pm.ed.icon
 
             else:
-                icon = 'SPACE3'
+                icon = 'HANDLETYPE_FREE_VEC'
                 if pm == apm:
-                    icon = 'SPACE2'
+                    icon = 'KEYTYPE_KEYFRAME_VEC'
 
             lh.operator(
                 WM_OT_pm_select.bl_idname, k, icon,
@@ -328,7 +328,7 @@ class PME_OT_panel_hide(bpy.types.Operator):
 
         lh.operator(
             PME_OT_panel_hide.bl_idname,
-            "New Hidden Panel Group", 'ZOOMIN',
+            "New Hidden Panel Group", 'ADD',
             group=pr.unique_pm_name(pr.ed('HPANEL').default_name),
             panel=self.panel)
 
@@ -2914,7 +2914,7 @@ class PME_OT_pmidata_specials_call(bpy.types.Operator):
 
         lh.sep()
 
-        lh.menu("PME_MT_screen_set", "Set Workspace", icon=ic('SPLITSCREEN'))
+        lh.menu("PME_MT_screen_set", "Set Workspace", icon=ic('MOUSE_MMB'))
         lh.menu("PME_MT_brush_set", "Set Brush", icon=ic('BRUSH_DATA'))
 
         if pm and pm.mode in {'PMENU', 'DIALOG'}:

--- a/operators.py
+++ b/operators.py
@@ -2546,8 +2546,7 @@ class PME_OT_docs(bpy.types.Operator):
     def execute(self, context):
         if self.id:
             self.url = (
-                "https://en.blender.org/index.php/User:Raa/"
-                "Addons/Pie_Menu_Editor"
+                "https://pluglug.github.io/pme-docs/"
             ) + self.id
         bpy.ops.wm.url_open(url=self.url)
         return {'FINISHED'}

--- a/operators.py
+++ b/operators.py
@@ -220,6 +220,81 @@ class PME_OT_exec(bpy.types.Operator):
         return self.execute(context)
 
 
+DBG_OVERRIDE = False  # TODO: Move to debug_utils
+class PME_OT_exec_override(bpy.types.Operator):
+    bl_idname = "pme.exec_override"
+    bl_label = ""
+    bl_description = "Execute python code with context override"
+    bl_options = {'INTERNAL'}
+
+    cmd: bpy.props.StringProperty(
+        name="Python Code", description="Python Code",
+        maxlen=MAX_STR_LEN, options={'SKIP_SAVE', 'HIDDEN'})
+    area_type: bpy.props.StringProperty(
+        name="Area Type",
+        default='CURRENT', maxlen=MAX_STR_LEN, options={'SKIP_SAVE', 'HIDDEN'})
+    region_type: bpy.props.StringProperty(
+        name="Region Type",
+        default='WINDOW', maxlen=MAX_STR_LEN, options={'SKIP_SAVE', 'HIDDEN'})
+    kwargs: bpy.props.StringProperty(
+        name="Extra Keywords",
+        description=(
+            "Python code that sets 'd' variable to override dict.\n"
+            "Example: w=C.window; d = {'area': w.screen.areas[0]}"
+        ),
+        default="d = {}", maxlen=MAX_STR_LEN, options={'SKIP_SAVE', 'HIDDEN'})
+
+    def execute(self, context):
+        DBG_OVERRIDE and logh(f"Executing: {self.cmd}")
+        temp_override_args = self.parse_kwargs()
+
+        temp_override_args.setdefault("area",
+            self.area_type if self.area_type != 'CURRENT' else None)
+        temp_override_args.setdefault("region", self.region_type)
+
+        if DBG_OVERRIDE:
+            pairs = [f"  {k}: {v}" for k, v in temp_override_args.items()]
+            logi("Context override args(defaults):\n" + "\n".join(pairs))
+
+        override_args = SU.ContextOverride(**temp_override_args)\
+                            .validate(context, delete_none=True)
+
+        if DBG_OVERRIDE:
+            pairs = [f"  {k}: {v}" for k, v in override_args.items()]
+            logi("Context override args(validated):\n" + "\n".join(pairs))
+
+        exec_globals = pme.context.gen_globals()
+        pme.context.exec_operator = self
+        try:
+            with context.temp_override(**override_args):
+                pme.context.exe(self.cmd, exec_globals)
+                return exec_globals.get("return_value", {'FINISHED'})
+        finally:
+            pme.context.exec_operator = None
+
+    def invoke(self, context, event):
+        pme.context.event = event
+        return self.execute(context)
+
+    def parse_kwargs(self):
+        """Execute kwargs code and get 'd' dict"""
+        if not self.kwargs.strip():
+            return {}
+
+        try:
+            code = compile(self.kwargs, "<override>", "exec")
+        except SyntaxError as e:
+            offset = e.offset if e.offset is not None else 0
+            pointer = " " * offset + "^"
+            self.report({'ERROR'},
+                f"Syntax error in override:\n{e.text}\n{pointer}\n{str(e)}")
+            return {}
+
+        eval_globals = pme.context.gen_globals()
+        pme.context.exe(code, eval_globals)
+        return eval_globals.get("d", {})
+
+
 class PME_OT_panel_hide(bpy.types.Operator):
     bl_idname = "pme.panel_hide"
     bl_label = "Hide Panel"
@@ -662,16 +737,13 @@ class PME_OT_timeout(bpy.types.Operator):
 
             if self.timer.time_duration >= self.delay:
                 self.cancelled = True
-                if False:
-                    pass
-                # if self.area != 'CURRENT':
-                #     bpy.ops.pme.timeout(
-                #         SU.override_context(self.area),
-                #         'INVOKE_DEFAULT', cmd=self.cmd, delay=self.delay)
-                else:
-                    pme.context.exec_operator = self
-                    pme.context.exe(self.cmd)
-                    pme.context.exec_operator = None
+                # if self.area != 'CURRENT':  # Refactor_TODO: Check why they no longer use Area.
+                #     with context.temp_override(area=self.area):
+                #         bpy.ops.pme.timeout('INVOKE_DEFAULT', cmd=self.cmd, delay=self.delay)
+                # else:
+                pme.context.exec_operator = self
+                pme.context.exe(self.cmd)
+                pme.context.exec_operator = None
         return {'PASS_THROUGH'}
 
     def execute(self, context):

--- a/overlay.py
+++ b/overlay.py
@@ -95,7 +95,7 @@ _line_y = 0
 
 def _draw_line(space, r, g, b, a):
     ctx = bpy.context
-    blf.size(0, space.size, 72)
+    blf.size(0, space.size)
     w, h = blf.dimensions(0, space.text)
 
     global _line_y
@@ -174,13 +174,13 @@ class Text:
 
     def update(self, text):
         self.text = text
-        blf.size(0, self.size, 72)
+        blf.size(0, self.size)
         self.width, self.height = blf.dimensions(0, text)
 
     def draw(self, x, y):
         blf_color(*self.style.color)
         blf.position(0, x, y, 0)
-        blf.size(0, self.size, 72)
+        blf.size(0, self.size)
         blf.draw(0, self.text)
 
 

--- a/preferences.py
+++ b/preferences.py
@@ -769,7 +769,7 @@ class WM_OT_pm_sort(bpy.types.Operator):
             mode='HOTKEY')
 
         lh.operator(
-            WM_OT_pm_sort.bl_idname, "Keymap Name", 'SPLITSCREEN',
+            WM_OT_pm_sort.bl_idname, "Keymap Name", 'MOUSE_MMB',
             mode='KEYMAP')
 
         lh.operator(
@@ -2214,7 +2214,7 @@ class PMEPreferences(bpy.types.AddonPreferences):
         name="Group by", description="Group items by",
         items=(
             ('NONE', "None", "", ic('CHECKBOX_DEHLT'), 0),
-            ('KEYMAP', "Keymap", "", ic('SPLITSCREEN'), 1),
+            ('KEYMAP', "Keymap", "", ic('MOUSE_MMB'), 1),
             ('TYPE', "Type", "", ic('PROP_CON'), 2),
             ('TAG', "Tag", "", ic('SOLO_OFF'), 3),
             ('KEY', "Key", "", ic('FILE_FONT'), 4),
@@ -2995,12 +2995,12 @@ class PMEPreferences(bpy.types.AddonPreferences):
                 lh.sep()
 
             lh.operator(
-                PME_OT_pm_add.bl_idname, "", 'ZOOMIN',
+                PME_OT_pm_add.bl_idname, "", 'ADD',
                 mode="")
 
             if pm:
-                lh.operator(WM_OT_pm_duplicate.bl_idname, "", 'GHOST')
-                lh.operator(PME_OT_pm_remove.bl_idname, "", 'ZOOMOUT')
+                lh.operator(WM_OT_pm_duplicate.bl_idname, "", 'DUPLICATE')
+                lh.operator(PME_OT_pm_remove.bl_idname, "", 'REMOVE')
 
             lh.sep()
 
@@ -3256,7 +3256,7 @@ class PMEPreferences(bpy.types.AddonPreferences):
             sub.prop(pr, "show_names", text="", icon=ic('SYNTAX_OFF'))
             sub.prop(pr, "show_hotkeys", text="", icon=ic('FILE_FONT'))
             sub.prop(
-                pr, "show_keymap_names", text="", icon=ic('SPLITSCREEN'))
+                pr, "show_keymap_names", text="", icon=ic('MOUSE_MMB'))
             sub.prop(pr, "show_tags", text="", icon=ic_fb(False))
             if pr.tree_mode:
                 sub.prop(pr, "group_by", text="", icon_only=True)
@@ -3509,12 +3509,12 @@ class PME_OT_context_menu(bpy.types.Operator):
             if self.prop or self.operator:
                 operator(
                     layout, PME_OT_context_menu.bl_idname,
-                    "Add to " + pm.name, icon=ic('ZOOMIN'),
+                    "Add to " + pm.name, icon=ic('ADD'),
                     prop=self.prop, operator=self.operator, name=self.name)
             else:
                 row = layout.row()
                 row.enabled = False
-                row.label(text="Can't Add This Widget", icon=ic('ZOOMIN'))
+                row.label(text="Can't Add This Widget", icon=ic('ADD'))
             layout.separator()
 
         operator(

--- a/preferences.py
+++ b/preferences.py
@@ -3106,11 +3106,13 @@ class PMEPreferences(bpy.types.AddonPreferences):
             self._draw_hprop(subcol, pr, "show_sidepanel_prefs")
             self._draw_hprop(
                 subcol, pr, "expand_item_menu",
-                "https://en.blender.org/uploads/b/b7/"
-                "Pme1.14.0_expand_item_menu.gif")
+                # "https://en.blender.org/uploads/b/b7/"
+                # "Pme1.14.0_expand_item_menu.gif"  # DOC_TODO: Create Content
+                )
             self._draw_hprop(
                 subcol, pr, "use_cmd_editor",
-                "https://en.blender.org/uploads/f/f4/Pme_item_edit.png")
+                # "https://en.blender.org/uploads/f/f4/Pme_item_edit.png"  # DOC_TODO: Create Content
+                )
             self._draw_hprop(subcol, pr, "cache_scripts")
             self._draw_hprop(subcol, pr, "save_tree")
             self._draw_hprop(subcol, pr, "auto_backup")
@@ -3206,8 +3208,9 @@ class PMEPreferences(bpy.types.AddonPreferences):
 
             self._draw_hlabel(
                 col, "Default Mode:",
-                "https://en.blender.org/index.php/User:Raa/Addons/"
-                "Pie_Menu_Editor/Editors/Popup_Dialog#Mode")
+                # "https://en.blender.org/index.php/User:Raa/Addons/"
+                # "Pie_Menu_Editor/Editors/Popup_Dialog#Mode"  # DOC_TODO: Create Content
+                )
             sub = col.row(align=True)
             sub.prop(pr, "default_popup_mode", expand=True)
 

--- a/preferences.py
+++ b/preferences.py
@@ -2306,11 +2306,22 @@ class PMEPreferences(bpy.types.AddonPreferences):
         bpy.app.debug_wm = value
 
     debug_mode: bpy.props.BoolProperty(
-        name="Debug Mode", description="Debug Mode\nShow error messages",
-        get=get_debug_mode, set=set_debug_mode)
-
-    # show_errors: bpy.props.BoolProperty(
-    #     description="Show error messages")
+        name="Debug Mode",
+        description=(
+            "Enables extended debug information (via bpy.app.debug_wm),\n"
+            "including operator logs for building custom PMEs."
+        ),
+        get=get_debug_mode,
+        set=set_debug_mode
+    )
+    show_error_trace: bpy.props.BoolProperty(
+        name="Show Error Trace",
+        description=(
+            "Displays error traces for custom items and more.\n"
+            "View them in the System Console to quickly identify and fix issues."
+        ),
+        default=True
+    )
 
     def update_tree_mode(self, context):
         if self.tree_mode:
@@ -3103,6 +3114,7 @@ class PMEPreferences(bpy.types.AddonPreferences):
             self._draw_hprop(subcol, pr, "cache_scripts")
             self._draw_hprop(subcol, pr, "save_tree")
             self._draw_hprop(subcol, pr, "auto_backup")
+            self._draw_hprop(subcol, pr, "show_error_trace")
             subcol.separator()
             self._draw_hprop(subcol, pr, "list_size")
             self._draw_hprop(subcol, pr, "num_list_rows")
@@ -3253,7 +3265,7 @@ class PMEPreferences(bpy.types.AddonPreferences):
 
         sub = row.row(align=True)
         sub.prop(pr, "interactive_panels", text="", icon=ic('WINDOW'))
-        # sub.prop(pr, "show_errors", text="", icon=ic('CONSOLE'))
+        # sub.prop(pr, "show_error_trace", text="", icon=ic('CONSOLE'))
         sub.prop(pr, "debug_mode", text="", icon=ic('SCRIPT'))
 
         # row.separator()

--- a/screen_utils.py
+++ b/screen_utils.py
@@ -1,8 +1,13 @@
 import bpy
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Union
+
 from . import c_utils as CTU
 from . import pme
 from .addon import uprefs
-from .bl_utils import ctx_dict
+# from .bl_utils import ctx_dict
+from .debug_utils import logi
 
 
 def redraw_screen(area=None):
@@ -10,8 +15,8 @@ def redraw_screen(area=None):
     # if not area:
     #     return
 
-    # bpy.ops.screen.screen_full_area(override_context(area))
-    # bpy.ops.screen.screen_full_area(override_context(area))
+    # with bpy.context.temp_override(area=area):
+    #     bpy.ops.screen.screen_full_area()
 
     view = uprefs().view
     s = view.ui_scale
@@ -19,12 +24,9 @@ def redraw_screen(area=None):
     view.ui_scale = s
 
 
-def toggle_header(context, area):
-    try:
-        bpy.ops.screen.header(context)
-    except:
-        area.spaces.active.show_region_header = \
-            not area.spaces.active.show_region_header
+def toggle_header(area):
+    area.spaces.active.show_region_header = \
+        not area.spaces.active.show_region_header
 
 
 def move_header(area=None, top=None, visible=None, auto=None):
@@ -51,53 +53,227 @@ def move_header(area=None, top=None, visible=None, auto=None):
     else:
         is_top = rh.y > area.y
 
-    d = ctx_dict(area=area, region=rh)
+    kwargs = get_override_args(area=area, region=rh)
     if auto:
         if top:
             if is_top:
-                toggle_header(d, area)
+                with bpy.context.temp_override(**kwargs):
+                    toggle_header(area)
             else:
-                bpy.ops.screen.region_flip(d)
-                not is_visible and toggle_header(d, area)
+                with bpy.context.temp_override(**kwargs):
+                    bpy.ops.screen.region_flip()
+                    not is_visible and toggle_header(area)
         else:
             if is_top:
-                bpy.ops.screen.region_flip(d)
-                not is_visible and toggle_header(d, area)
+                with bpy.context.temp_override(**kwargs):
+                    bpy.ops.screen.region_flip()
+                    not is_visible and toggle_header(area)
             else:
-                toggle_header(d, area)
+                with bpy.context.temp_override(**kwargs):
+                    toggle_header(area)
     else:
-        top is not None and top != is_top and bpy.ops.screen.region_flip(d)
-        if visible is not None and visible != is_visible:
-            toggle_header(d, area)
+        if top is not None and top != is_top:
+            with bpy.context.temp_override(**kwargs):
+                bpy.ops.screen.region_flip()
 
+        if visible is not None and visible != is_visible:
+            with bpy.context.temp_override(**kwargs):
+                toggle_header(area)
     return True
 
 
-def find_area(area_type, screen=None):
-    screen = screen or bpy.context.screen
-    if isinstance(screen, str):
-        screen = bpy.data.screens.get(screen, None)
+# def parse_extra_keywords(kwargs_str: str) -> dict:
+#     """
+#     Parse a comma-separated string like:
+#       "window=Window, screen=Screen.001, workspace=MyWorkspace"
+#     into a dict:
+#       { "window": "Window", "screen": "Screen.001", "workspace": "MyWorkspace" }
+#     """
+#     if not kwargs_str.strip():
+#         return {}
+#     kwargs = {}
+#     for kv in kwargs_str.split(","):
+#         kv = kv.strip()
+#         if "=" not in kv:
+#             continue
+#         k, v = kv.split("=", 1)
+#         kwargs[k.strip()] = v.strip()
+#     return kwargs
 
-    if screen:
-        for a in screen.areas:
-            if a.type == area_type:
-                return a
+
+def find_area(
+    area_or_type: Union[str, bpy.types.Area, None],
+    screen_or_name: Union[str, bpy.types.Screen, None] = None
+) -> Optional[bpy.types.Area]:
+    """Find and return an Area object, or None if not found."""
+    try:
+        if area_or_type is None:
+            # return bpy.context.area  # fallback
+            return None
+
+        if isinstance(area_or_type, bpy.types.Area):
+            return area_or_type
+
+        # Find screen
+        screen = None
+        if isinstance(screen_or_name, bpy.types.Screen):
+            screen = screen_or_name
+        elif isinstance(screen_or_name, str):
+            screen = bpy.data.screens.get(screen_or_name)
+        else:
+            screen = bpy.context.screen
+
+        if screen:
+            for a in screen.areas:
+                if a.type == area_or_type:
+                    return a
+
+    except ReferenceError:
+        # print_exc("find_area: invalid reference")
+        pass
 
     return None
 
 
-def find_region(area, region_type):
-    for r in area.regions:
-        if r.type == region_type:
-            return r
+def find_region(
+    region_or_type: Union[str, bpy.types.Region, None],
+    area_or_type: Union[str, bpy.types.Area, None] = None,
+    screen_or_name: Union[str, bpy.types.Screen, None] = None
+) -> Optional[bpy.types.Region]:
+    """Find and return a Region object within the specified Area, or None if not found."""
+    try:
+        if region_or_type is None:
+            # return bpy.context.region  # fallback
+            return None
+
+        if isinstance(region_or_type, bpy.types.Region):
+            return region_or_type
+
+        area = find_area(area_or_type, screen_or_name)
+        if not area:
+            return None
+
+        for r in area.regions:
+            if r.type == region_or_type:
+                return r
+
+    except ReferenceError:
+        # print_exc("find_region: invalid reference")
+        pass
 
     return None
+
+
+def find_window(
+    value: Optional[Union[str, bpy.types.Window]],
+    context: bpy.types.Context,
+) -> Optional[bpy.types.Window]:
+    """Resolve string or Window object into a Window object, fallback to context.window if none."""
+    if isinstance(value, bpy.types.Window):
+        logi(f"find_window: {value}")
+        return value
+    # if isinstance(value, str):
+    #     if w := context.window_manager.windows.get(value, None):
+    #         return w
+    #     return None
+    # logi(f"window fallback: {context.window}")
+    # return context.window  # fallback
+    return None
+
+
+def find_screen(
+    value: Optional[Union[str, bpy.types.Screen]],
+    context: bpy.types.Context
+) -> Optional[bpy.types.Screen]:
+    """Resolve string or Screen object into a Screen object, fallback to context.screen if none."""
+    if isinstance(value, bpy.types.Screen):
+        logi(f"find_screen: {value}")
+        return value
+    # if isinstance(value, str):
+    #     return bpy.data.screens.get(value)
+    # logi(f"screen fallback: {context.screen}")
+    # return context.screen  # fallback
+    return None
+
+
+class ContextOverride:
+    def __init__(
+        self,
+        *,
+        window: Union[str, bpy.types.Window, None] = None,
+        screen: Union[str, bpy.types.Screen, None] = None,
+        area: Union[str, bpy.types.Area, None] = None,
+        region: Union[str, bpy.types.Region, None] = None,
+        **kwargs: Any,
+    ):
+        self.window = window
+        self.screen = screen
+        self.area = area
+        self.region = region
+        self.kwargs = kwargs
+
+    def validate(
+        self,
+        context: bpy.types.Context,
+        *,
+        # extra_priority: bool = False,
+        delete_none: bool = True
+    ) -> Dict[str, Any]:
+
+        # Resolve all fields
+        w = find_window(self.window, context)
+        sc = find_screen(self.screen, context)
+        a = find_area(self.area, sc)
+        r = find_region(self.region, self.area, sc)
+        # bd = self.blend_data  # or context.blend_data
+
+        base_dict = {
+            "window": w,
+            "screen": sc,
+            "area": a,
+            "region": r,
+            # "blend_data": bd,
+        }
+
+        context_params = {**base_dict, **self.kwargs}
+
+        if delete_none:
+            context_params = {k: v for k, v in context_params.items() if v is not None}
+
+        return context_params
+
+    def __str__(self):
+        return (
+            f"ContextOverride(\n"
+            f"  window={self.window},\n"
+            f"  screen={self.screen},\n"
+            f"  area={self.area},\n"
+            f"  region={self.region},\n"
+            f"  kwargs={self.kwargs})\n"
+        )
+
+
+def get_override_args(
+    area: Union[str, bpy.types.Area] = None,
+    region: Union[str, bpy.types.Region] = "WINDOW",
+    screen: Union[str, bpy.types.Screen] = None,
+    window: Union[str, bpy.types.Window] = None,
+    delete_none: bool = True,
+    **kwargs,
+) -> dict:
+    """Get a dictionary of context override arguments."""
+    override = ContextOverride(
+        area=area,
+        region=region,
+        screen=screen,
+        window=window,
+        **kwargs,
+    )
+    return override.validate(bpy.context, delete_none=delete_none)
 
 
 def focus_area(area, center=False, cmd=None):
-    if isinstance(area, str):
-        area = find_area(area)
-
+    area = find_area(area)
     if not area:
         return
 
@@ -123,51 +299,30 @@ def focus_area(area, center=False, cmd=None):
         bpy.context.window.cursor_warp(x, y)
 
     if cmd:
-        bpy.ops.pme.timeout(override_context(area), cmd=cmd)
+        with bpy.context.temp_override(area=area):
+            bpy.ops.pme.timeout(cmd=cmd)
 
 
+# TODO: Remove this function
 def override_context(
         area, screen=None, window=None, region='WINDOW', **kwargs):
-    window = window or bpy.context.window
-    screen = screen or bpy.context.screen
-    region = region or bpy.context.region
+    # This is no longer necessary
+    # but is documented in the old user docs so keeping it for now
 
-    if isinstance(screen, str):
-        screen = bpy.data.screens.get(screen, bpy.context.screen)
-
-    if not screen:
-        return dict()
-
-    if isinstance(area, str):
-        for a in screen.areas:
-            if a.type == area:
-                area = a
-                break
-        else:
-            return dict()
-
-    if isinstance(region, str):
-        for r in area.regions:
-            if r.type == region:
-                region = r
-                break
-        else:
-            region = area.regions[0]
-
-    return dict(
-        region=region,
-        area=area,
-        screen=screen,
-        window=window,
-        blend_data=bpy.context.blend_data,
-        **kwargs
+    import traceback
+    import warnings
+    caller = traceback.extract_stack(None, 2)[0]
+    warnings.warn(
+        f"Deprecated: 'override_context' is deprecated, use 'get_override_args' instead. "
+        f"Called from {caller.name} at {caller.line}",
+        DeprecationWarning,
+        stacklevel=2
     )
+    return get_override_args(area, region, screen, window, **kwargs)
 
 
 def toggle_sidebar(area=None, tools=True, value=None):
-    area = area or bpy.context.area
-    if isinstance(area, str):
-        area = find_area(area)
+    area = find_area(area)
 
     s = area.spaces.active
     if tools and hasattr(s, "show_region_toolbar"):


### PR DESCRIPTION
### Description
This PR consolidates the extended context override functionality required for Blender 4.0 compatibility, along with various related fixes and refactoring. Centered around `temp_override`, it includes migrating from dictionary-based overrides (C_dict), improving debugging capabilities, updating icon identifiers, and more.

### Main Changes

1. **Blender 4.0 compatibility: Removing the `dpi` argument from `blf.size()`**  
   - Removed the deprecated `dpi=72` argument from `overlay.py`  
   - Backward compatibility is maintained since the default value remains 72  

2. **Introducing `temp_override` and deprecating dictionary-based overrides**  
   - Replaced the dictionary-based context overrides (C_dict) used in various places  
   - Added the `PME_OT_exec_override` operator  
   - Introduced the `ContextOverride` class with enhanced validation  
   - Removed the C_dict return value from `parse_pos_args`  

3. **Enhanced type checking in `find_area/region` utilities**  
   - Implemented integrated override handling via `get_override_args`  
   - Added deprecation paths for `ctx_dict` and `override_context`  

4. **Updated sample code**  
   - Changed `examples/window_area_pie.json` to a sample that uses the new `pme.exec_override` operator  

5. **Improvements to PMI error reporting**  
   - Changed the default setting so that errors are no longer hidden  
   - Added the `show_error_trace` property and separated its role from `debug_mode`  

6. **Other fixes and adjustments**  
   - Updated icon identifiers inherited from Blender 2.79  
   - Temporarily removed `c_last_btn` calls to avoid NULL pointer access  
   - Addressed cases where `bpy.context.area` becomes `None`  
   - Fixed side area detection to respect the UI line width preference  
   - Migrated documentation URLs to the new website  
   - Updated version to 1.18.8 and added contributor information  
