### PR TITLE
Experimental Click + Click Drag Modes (zip attached)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -214,6 +214,10 @@ OPEN_MODE_ITEMS = (
         ph.get_icon("pTweak"), 3),
     ('CHORDS', "Key Chords", "Click sequence of 2 keys",
         ph.get_icon("pChord"), 4),
+    ('CLICK', "Click (TEST)", "Click the key", 
+        ph.get_icon("pPress"), 5),
+    ('CLICK_DRAG', "Click Drag (TEST)", "Click and drag the key", 
+        ph.get_icon("pTweak"), 6),
 )
 
 

--- a/keymap_helper.py
+++ b/keymap_helper.py
@@ -675,6 +675,10 @@ def to_ui_hotkey(data):
             hotkey += "%sx2" % key_names[data.key]
         elif data.open_mode == 'CHORDS':
             hotkey += "%s, %s" % (key_names[data.key], key_names[data.chord])
+        elif data.open_mode == 'CLICK':
+            hotkey += "<%s>" % key_names[data.key]
+        elif data.open_mode == 'CLICK_DRAG':
+            hotkey += "<<%s>>" % key_names[data.key]
     else:
         hotkey += key_names[data.key]
 

--- a/operators.py
+++ b/operators.py
@@ -2060,7 +2060,9 @@ class WM_OT_pme_user_pie_menu_call(bpy.types.Operator):
     def _parse_open_mode(self, pm):
         if pm.open_mode == 'HOLD':
             self.pm_hold = pm
-        elif pm.open_mode == 'PRESS':
+        # elif pm.open_mode == 'PRESS':
+        #     self.pm_press = pm
+        elif pm.open_mode in {'PRESS', 'CLICK', 'CLICK_DRAG'}:  # XXX: Not verified
             self.pm_press = pm
         elif pm.open_mode == 'CHORDS':
             self.pm_chord = pm

--- a/types.py
+++ b/types.py
@@ -347,9 +347,15 @@ class PMItem(bpy.types.PropertyGroup):
                     kmi.oskey = self.oskey
 
                 kmi.key_modifier = self.key_mod
-                kmi.value = \
-                    'DOUBLE_CLICK' if self.open_mode == 'DOUBLE_CLICK' \
-                    else 'PRESS'
+                # kmi.value = \
+                #     'DOUBLE_CLICK' if self.open_mode == 'DOUBLE_CLICK' \
+                #     else 'PRESS'
+
+                kmi.value = {
+                    "DOUBLE_CLICK": "DOUBLE_CLICK",
+                    "CLICK": "CLICK",
+                    "CLICK_DRAG": "CLICK_DRAG"
+                }.get(self.open_mode, "PRESS")
 
                 if self.key == 'NONE' or not self.enabled:
                     if pr.kh.available():
@@ -712,9 +718,15 @@ class PMItem(bpy.types.PropertyGroup):
                     kmi.properties.invoke_mode = 'HOTKEY'
                     kmi.properties.keymap = km_name
 
-                    kmi.value = \
-                        'DOUBLE_CLICK' if self.open_mode == 'DOUBLE_CLICK' \
-                        else 'PRESS'
+                    # kmi.value = \
+                    #     'DOUBLE_CLICK' if self.open_mode == 'DOUBLE_CLICK' \
+                    #     else 'PRESS'  # Comment out for testing
+
+                    kmi.value = {
+                        "DOUBLE_CLICK": "DOUBLE_CLICK",
+                        "CLICK": "CLICK",
+                        "CLICK_DRAG": "CLICK_DRAG"
+                    }.get(self.open_mode, "PRESS")  # Change
 
                     if self.kmis_map[self.name]:
                         self.kmis_map[self.name][km_name] = kmi


### PR DESCRIPTION
Hey everyone,

This PR introduces experimental “Click” and “Click Drag” modes for PME. As requested in #20, I’ve bundled these features in a test build so that only those who are interested can try them out. Please find the attached zip file below!

### Why It’s Experimental
- **Click Drag with Directions**: In Blender, Click Drag can handle different directions, and we might want to incorporate that into PME in the future. (I already have some personal use cases in mind, but I’m not sure how complex it would be to implement—or how many people really need it.)
- **Repeat Option**: Another separate idea is Blender’s Keymap “Repeat” feature. It could boost workflow efficiency if we figure out a way to integrate it into PME. Again, complexity and demand are unknown.
- **Complexity in PME**: PME is getting more intricate when it comes to how menus are called, so even if something isn’t too difficult, it might still take time to implement. Sometimes it feels like everything lives inside roaoao’s head!

### Important Notes
- The example from #20 (thanks @AVA3d!) has proven useful for testing this feature.
- There shouldn’t be any major issues, but please keep in mind this is a **test phase**. Errors or unexpected compatibility quirks could happen if we change the underlying specs in the future. (Identifiers are pretty stable, so hopefully there won’t be any drama!)
- Please share your use cases! The more we learn about your workflows, the better we can refine these features. If you encounter any errors, let us know right away.

### Next Steps
We’re aiming to include these modes in **v1.19.0**, pending feedback. Feel free to leave comments or questions here in the PR.

Happy testing, and thank you for helping us improve PME!