### PR TITLE
Missing icon spam fix

### DIFF
--- a/previews_helper.py
+++ b/previews_helper.py
@@ -11,9 +11,13 @@ class PreviewsHelper:
         self.preview = None
 
     def get_icon(self, name):
+        if self.preview is None or name not in self.preview:
+            return 0
         return self.preview[name].icon_id
 
     def get_icon_name_by_id(self, id):
+        if self.preview is None:
+            return None
         name = None
         min_id = 99999999
         for k, i in self.preview.items():
@@ -26,10 +30,12 @@ class PreviewsHelper:
         return name
 
     def get_names(self):
+        if self.preview is None:
+            return []
         return self.preview.keys()
 
     def has_icon(self, name):
-        return name in self.preview
+        return self.preview is not None and name in self.preview
 
     def refresh(self):
         if self.preview:
@@ -55,9 +61,6 @@ class PreviewsHelper:
 def custom_icon(icon):
     return ph.get_icon(icon)
 
-
-if "ph" in globals():
-    ph.unregister()
 
 ph = PreviewsHelper()
 ph.refresh()

--- a/previews_helper.py
+++ b/previews_helper.py
@@ -62,6 +62,9 @@ def custom_icon(icon):
     return ph.get_icon(icon)
 
 
+if "ph" in globals():
+    ph.unregister()
+
 ph = PreviewsHelper()
 ph.refresh()
 


### PR DESCRIPTION
Fix TypeError when preview icons aren't loaded

Sometimes if there is a missing icon ID for any reason, pme will produce massive error spam to console. Added null checks to prevent errors when self.preview is None.

- has_icon() now returns False instead of crashing
- get_icon() returns 0 when icon id not found. Meaning is it will fallback to icon id 0 in case of missing icon
- get_names() returns empty list when preview is None

