### PR TITLE
WIP: fix pr["attribute"] in 5.0 cause by api changes

### DIFF
--- a/preferences.py
+++ b/preferences.py
@@ -3812,7 +3812,8 @@ def register():
     pr.maximize_prefs = False
     pr.show_advanced_settings = False
     pr.mode_filter = CC.PM_ITEMS_M_DEFAULT
-    pr["tag_filter"] = ""
+    if hasattr(pr,"tag_filter"):
+        pr.tag_filter = ""
     Tag.filter()
 
     h = pr.hotkey


### PR DESCRIPTION
get props change in 5.0 [removal-of-unsuported-access-to-runtime-defined-properties-storage-data](https://developer.blender.org/docs/release_notes/5.0/python_api/#removal-of-unsuported-access-to-runtime-defined-properties-storage-data)
so get preference like this will failed `pr["tag_filter"] = ""`

---

pr["active_pie_menu_idx"] is the next thing need to fix
```
TypeError: this type doesn't support IDProperties
File "C:\Program Files (x86)\Steam\steamapps\common\Blender\portable\scripts\addons\pie_menu_editor\preferences.py", line 2145, in pie_menu_idx_get
Traceback (most recent call last):
  File "C:\Program Files (x86)\Steam\steamapps\common\Blender\portable\scripts\addons\pie_menu_editor\preferences.py", line 2146, in pie_menu_idx_get
    return self.get("active_pie_menu_idx", 0)
```
However, change the get function in property register below will crash blender. 
Old
```python
def pie_menu_idx_get(self):
    return self.get("active_pie_menu_idx", 0)

def pie_menu_idx_set(self, value):
    if self.active_pie_menu_idx == value:
        return

    self["active_pie_menu_idx"] = value
    self.pmi_data.info()
    temp_prefs().hidden_panels_idx = 0
    if self.active_pie_menu_idx >= 0:
        self.selected_pm.ed.on_pm_select(self.selected_pm)

active_pie_menu_idx: bpy.props.IntProperty(
    get=pie_menu_idx_get, set=pie_menu_idx_set
)
```
new
```python
def pie_menu_idx_get(self):
    if hasattr(self,"active_pie_menu_idx"):
        return self.active_pie_menu_idx
    return 0

def pie_menu_idx_set(self, value):
    if self.active_pie_menu_idx == value:
        return

    self["active_pie_menu_idx"] = value
    self.pmi_data.info()
    temp_prefs().hidden_panels_idx = 0
    if self.active_pie_menu_idx >= 0:
        self.selected_pm.ed.on_pm_select(self.selected_pm)

active_pie_menu_idx: bpy.props.IntProperty(
    get=pie_menu_idx_get, set=pie_menu_idx_set
)
```
Something need to report to blender issue later